### PR TITLE
Update install_buffet.sh to use new bundle of llvm

### DIFF
--- a/install_buffet.sh
+++ b/install_buffet.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 cd compiler/buffetfsm/
-tar xjvf ../../thirdparty/llvm_clang-r209914-buffet_fsm_patch.tar.bz2
+tar xjvf ../../thirdparty/llvm_clang-r209914-patched-buffet_fsm_patch.tar.bz2
 mkdir toolchain
 mkdir llvm-build
 cd llvm-build


### PR DESCRIPTION
Fix `install_buffet.sh` that broke with 26a5ea3