### PR TITLE
fix: build error of kyotocabinet with gcc6

### DIFF
--- a/thirdparty/gcc6-workaround.patch
+++ b/thirdparty/gcc6-workaround.patch
@@ -1,0 +1,13 @@
+diff --git a/kcdbext.h b/kcdbext.h
+index 001c09a..93c612d 100644
+--- a/kcdbext.h
++++ b/kcdbext.h
+@@ -1278,7 +1278,7 @@ class IndexDB {
+     if (omode_ == 0) {
+       set_error(_KCCODELINE_, BasicDB::Error::INVALID, "not opened");
+       *sp = 0;
+-      return false;
++      return NULL;
+     }
+     if (!cache_) return db_.get(kbuf, ksiz, sp);
+     size_t dvsiz = 0;

--- a/thirdparty/install_pepper_deps.sh
+++ b/thirdparty/install_pepper_deps.sh
@@ -38,7 +38,9 @@ cd $UP
 #Kyoto Cabinet
 echo "installing Kyoto Cabinet"
 $TAR kyotocabinet-1.2.76.tar.gz
+cp gcc6-workaround.patch kyotocabinet-1.2.76
 cd kyotocabinet-1.2.76
+patch -p1 < gcc6-workaround.patch
 ./configure --prefix=$DEPS_DIR
 make
 make install
@@ -55,7 +57,7 @@ cd $UP
 
 #libsnark
 echo "installing libsnark"
-git clone https://github.com/scipr-lab/libsnark.git
+[ ! -d libsnark ] && git clone https://github.com/scipr-lab/libsnark.git
 cd libsnark
 ./prepare-depends.sh
 make install STATIC=1 NO_PROCPS=1 PREFIX=$DEPS_DIR


### PR DESCRIPTION
This PR solves the following problems
1. "./install_debian_ubuntu.sh" failed with gcc6 (I assume that Kyotocabinet should fix that in the future, thus this is just workaround)
2. when run "./install_debian_ubuntu.sh" twice for rebuild, the second time fails by git clone against existing directory

my gcc environment (out-of-box version in ubuntu 17.04)

```
% gcc -v
Using built-in specs.
COLLECT_GCC=gcc
COLLECT_LTO_WRAPPER=/usr/lib/gcc/x86_64-linux-gnu/6/lto-wrapper
Target: x86_64-linux-gnu
Configured with: ../src/configure -v --with-pkgversion='Ubuntu 6.3.0-12ubuntu2' --with-bugurl=file:///usr/share/doc/gcc-6/README.Bugs --enable-languages=c,ada,c++,java,go,d,fortran,objc,obj-c++ --prefix=/usr --program-suffix=-6 --program-prefix=x86_64-linux-gnu- --enable-shared --enable-linker-build-id --libexecdir=/usr/lib --without-included-gettext --enable-threads=posix --libdir=/usr/lib --enable-nls --with-sysroot=/ --enable-clocale=gnu --enable-libstdcxx-debug --enable-libstdcxx-time=yes --with-default-libstdcxx-abi=new --enable-gnu-unique-object --disable-vtable-verify --enable-libmpx --enable-plugin --enable-default-pie --with-system-zlib --disable-browser-plugin --enable-java-awt=gtk --enable-gtk-cairo --with-java-home=/usr/lib/jvm/java-1.5.0-gcj-6-amd64/jre --enable-java-home --with-jvm-root-dir=/usr/lib/jvm/java-1.5.0-gcj-6-amd64 --with-jvm-jar-dir=/usr/lib/jvm-exports/java-1.5.0-gcj-6-amd64 --with-arch-directory=amd64 --with-ecj-jar=/usr/share/java/eclipse-ecj.jar --with-target-system-zlib --enable-objc-gc=auto --enable-multiarch --disable-werror --with-arch-32=i686 --with-abi=m64 --with-multilib-list=m32,m64,mx32 --enable-multilib --with-tune=generic --enable-checking=release --build=x86_64-linux-gnu --host=x86_64-linux-gnu --target=x86_64-linux-gnu
Thread model: posix
gcc version 6.3.0 20170406 (Ubuntu 6.3.0-12ubuntu2) 
```

the error message i met

```
#================================================================
# Ready to make.
#================================================================
g++ -c -I. -I/home/takeoka/pepper_deps/include -I/usr/local/include -DNDEBUG -D_GNU_SOURCE=1 -D_FILE_OFFSET_BITS=64 -D_REENTRANT -D__EXTENSIONS__ -D_MYZLIB -D_MYGCCATOMIC -D_KC_PREFIX="\"/home/takeoka/pepper_deps\"" -D_KC_INCLUDEDIR="\"/home/takeoka/pepper_deps/include\"" -D_KC_LIBDIR="\"/home/takeoka/pepper_deps/lib\"" -D_KC_BINDIR="\"/home/takeoka/pepper_deps/bin\"" -D_KC_LIBEXECDIR="\"/home/takeoka/pepper_deps/libexec\"" -D_KC_APPINC="\"-I/home/takeoka/pepper_deps/include\"" -D_KC_APPLIBS="\"-L/home/takeoka/pepper_deps/lib -lkyotocabinet -lz -lstdc++ -lrt -lpthread -lm -lc \"" -march=native -m64 -g -O2 -Wall -fPIC -fsigned-char -g0 -O2 -Wno-unused-but-set-variable -Wno-unused-but-set-parameter kcdbext.cc
In file included from kcdbext.cc:16:0:
kcdbext.h: In member function ‘char* kyotocabinet::IndexDB::get(const char*, size_t, size_t*)’:
kcdbext.h:1281:14: error: cannot convert ‘bool’ to ‘char*’ in return
       return false;
              ^~~~~
Makefile:76: recipe for target 'kcdbext.o' failed
```