### PR TITLE
add srand for random input generation

### DIFF
--- a/pepper/input_generation/kmpsearch_flat_v_inp_gen.h
+++ b/pepper/input_generation/kmpsearch_flat_v_inp_gen.h
@@ -1,7 +1,7 @@
 
 
 void kmpsearch_flat_input_gen (mpq_t * input_q, int num_inputs) {
-
+    srand(time(NULL));
     for (int i = 0; i < num_inputs; i++) {
         mpq_set_ui(input_q[i], rand() % 256, 1);
     }

--- a/pepper/input_generation/kmpsearch_v_inp_gen.h
+++ b/pepper/input_generation/kmpsearch_v_inp_gen.h
@@ -1,7 +1,7 @@
 
 
 void kmpsearch_input_gen (mpq_t * input_q, int num_inputs) {
-
+    srand(time(NULL));
     for (int i = 0; i < num_inputs; i++) {
         mpq_set_ui(input_q[i], rand() % 256, 1);
     }

--- a/pepper/input_generation/mergesort_benes_v_inp_gen.h
+++ b/pepper/input_generation/mergesort_benes_v_inp_gen.h
@@ -1,7 +1,7 @@
 
 
 void mergesort_benes_input_gen (mpq_t * input_q, int num_inputs) {
-
+    srand(time(NULL));
     for (int i = 0; i < num_inputs; i++) {
         mpq_set_ui(input_q[i], rand() % 10, 1);
     }

--- a/pepper/input_generation/mm_pure_arith_v_inp_gen.h
+++ b/pepper/input_generation/mm_pure_arith_v_inp_gen.h
@@ -1,7 +1,7 @@
 
 
 void mm_pure_arith_input_gen (mpq_t * input_q, int num_inputs) {
-
+    srand(time(NULL));
     for (int i = 0; i < num_inputs; i++) {
         mpq_set_ui(input_q[i], rand(), 1);
     }

--- a/pepper/input_generation/pam_clustering_v_inp_gen.h
+++ b/pepper/input_generation/pam_clustering_v_inp_gen.h
@@ -1,7 +1,7 @@
 
 
 void pam_clustering_input_gen (mpq_t * input_q, int num_inputs) {
-
+    srand(time(NULL));
     for (int i = 0; i < num_inputs; i++) {
         mpq_set_ui(input_q[i], rand(), 1);
     }

--- a/pepper/input_generation/pure_hashput_v_inp_gen.h
+++ b/pepper/input_generation/pure_hashput_v_inp_gen.h
@@ -1,7 +1,7 @@
 
 
 void pure_hashput_input_gen (mpq_t * input_q, int num_inputs) {
-
+    srand(time(NULL));
     for (int i = 0; i < num_inputs; i++) {
         mpq_set_ui(input_q[i], rand(), 1);
     }

--- a/pepper/input_generation/rle_decode_flat_v_inp_gen.h
+++ b/pepper/input_generation/rle_decode_flat_v_inp_gen.h
@@ -1,7 +1,7 @@
 
 
 void rle_decode_flat_input_gen (mpq_t * input_q, int num_inputs) {
-
+    srand(time(NULL));
     for (int i = 0; i < num_inputs; i++) {
         mpq_set_ui(input_q[i], rand() % 10, 1);
     }

--- a/pepper/input_generation/rle_decode_v_inp_gen.h
+++ b/pepper/input_generation/rle_decode_v_inp_gen.h
@@ -1,7 +1,7 @@
 
 
 void rle_decode_input_gen (mpq_t * input_q, int num_inputs) {
-
+    srand(time(NULL));
     for (int i = 0; i < num_inputs; i++) {
         mpq_set_ui(input_q[i], rand() % 10, 1);
     }

--- a/pepper/input_generation/tolling_v_inp_gen.h
+++ b/pepper/input_generation/tolling_v_inp_gen.h
@@ -1,7 +1,7 @@
 
 
 void tolling_input_gen (mpq_t * input_q, int num_inputs) {
-
+    srand(time(NULL));
     for (int i = 0; i < num_inputs; i++) {
         mpq_set_ui(input_q[i], rand(), 1);
     }


### PR DESCRIPTION
input-generation should use **rand** after setting seed via **srand**, otherwise it always generates the same input value set.

I was confused because it was exactly same when I tried to run prover and verifier with different input.
I'm not expert of formal verification, thus please correct me if I misunderstand something.