### PR TITLE
Introducing type int128

### DIFF
--- a/compiler/frontend/src/C.flex
+++ b/compiler/frontend/src/C.flex
@@ -137,6 +137,7 @@ Comment = {TraditionalComment} | {EndOfLineComment}
   "else"      { return token(ELSE); }
   "enum"      { return token(ENUM); }
   "extern"    { return token(EXTERN); }
+  "int128"     { return token(INT128); }
   "float"      { return token(FLOAT); }
   "for"      { return token(FOR); }
   "goto"      { return token(GOTO); }

--- a/compiler/frontend/src/C.grammar
+++ b/compiler/frontend/src/C.grammar
@@ -45,7 +45,7 @@ XOR_ASSIGN,OR_ASSIGN,TYPE_NAME,ASSIGN,
 
 TYPEDEF,EXTERN,STATIC,AUTO,REGISTER,
 INLINE,NORETURN,
-CHAR,SHORT,INT,LONG,SIGNED,UNSIGNED,FLOAT,DOUBLE,CONST,VOLATILE,VOID,
+CHAR,SHORT,INT,LONG,SIGNED,UNSIGNED,FLOAT,DOUBLE,CONST,VOLATILE,VOID,INT128,
 STRUCT,UNION,ENUM,ELLIPSIS,
 
 CASE,DEFAULT,IF,ELSE,SWITCH,WHILE,DO,FOR,GOTO,CONTINUE,BREAK,RETURN,
@@ -352,6 +352,7 @@ type_specifier
   | struct_or_union_specifier.a {: return new Symbol(a); :}
   | enum_specifier {: throw new RuntimeException(placeholder_re); :}
   | TYPE_NAME.a {: return new Symbol(new TypeSpecification(a)); :}
+  | INT128 {: return new Symbol(new TypeSpecification("int128")); :}
   ;
 
 struct_or_union_specifier

--- a/compiler/frontend/src/ccomp/parser_hw/CCompiler.java
+++ b/compiler/frontend/src/ccomp/parser_hw/CCompiler.java
@@ -1782,6 +1782,9 @@ public class CCompiler {
 					intType(signString, 64)); // "At least 64 bits in size"
 			typetable.put(join(signString, "long long int"),
 					intType(signString, 64)); // "At least 64 bits in size"
+
+			// NONSTANDARD "int128" extension
+			typetable.put(join(signString, "int128"), intType(signString, 128));
 		}
 
 		// NONSTANDARD "bool" extension


### PR DESCRIPTION
As discussed in #18 it would be great to have support for types larger than 64 bit. This PR introduces a new type that is 128 bits wide.

I tested the change by compiling this program

```c
struct In {unsigned int128 lhs; unsigned int128 rhs; };
struct Out { unsigned int128 result; };

void compute(struct In *input, struct Out *output) {
  output->result = input->lhs + input->rhs;
}
```

and making sure that I can prove and verify it with integers > 64 bit.

The generated `spec_tmp` file looks like this:

```
START_INPUT
I0 //__malloc0.lhs uint bits 128
I1 //__malloc0.rhs uint bits 128
END_INPUT

START_OUTPUT
O6 //#compute$__compute__ uint bits 1
O7 //__malloc1.result uint bits 129
END_OUTPUT

START_VARIABLES
END_VARIABLES

START_CONSTRAINTS
(  ) * (  ) + (  - O6 )
(  ) * (  ) + ( I0 + I1 - O7 )
END_CONSTRAINTS
```

I also ran the original example from #18 and made sure it works