### PR TITLE
Adding support to call into external libsnark gadgets

### DIFF
--- a/compiler/backend/zcc_parser.py
+++ b/compiler/backend/zcc_parser.py
@@ -1694,13 +1694,20 @@ Expecting `[{{aIndex: aValue, ...}}, {{bIndex: bValue, ...}}, {{cIndex: cValue, 
         # Insert constraints into matrices
         for matrix, out in {0: fp_matrix_a, 1: fp_matrix_b, 2: fp_matrix_c}.iteritems():
           for index, value in constraints[matrix].iteritems():
+            if value == "0":
+              continue
             index  = int(index)
             # remap index to correct variable name, unless it's 0 (meaning constant 1)
             if index != 0:
               (_, varName) = to_var(varList[index-1])
               index = convert_variable_to_index(varName, shuffled_indices)
-            out.write("{} {} {}".format(index, j, value))
-            
+              assert index != 0
+
+            # Libsnark constraints are A*B = C, vs. A*B - C = 0 for Zaatar.
+            # Which is why the C coefficient is negated.
+            if (matrix == 2):
+              value = "-" + value;
+            out.write("{} {} {}\n".format(index, j, value))
         j = j + 1
         num_constraints = num_constraints + 1
     else:

--- a/compiler/backend/zcc_parser.py
+++ b/compiler/backend/zcc_parser.py
@@ -1025,9 +1025,14 @@ def parse_ext_gadget_spec_line(terms):
   
   assert terms[cTok] == "INTERMEDIATE"
   cTok += 1
-  
   numIntermediate = int(terms[cTok])
-  intermediateVars = map(lambda i: "G{}V{}".format(gadgetId, i), range(0, numIntermediate))
+  cTok += 1
+
+  assert terms[cTok] == "OFFSET"
+  cTok += 1
+  offset = long(terms[cTok])
+  
+  intermediateVars = map(lambda i: "G{}V{}".format(gadgetId, i), range(offset, offset+numIntermediate))
 
   return (inVars,outVars,intermediateVars,gadgetId)
 

--- a/compiler/backend/zcc_parser.py
+++ b/compiler/backend/zcc_parser.py
@@ -9,6 +9,8 @@ import zcc_parser_static
 import collections
 import var_table
 import merkle
+import subprocess
+import json
 
 import wak
 
@@ -986,7 +988,7 @@ def parse_exo_compute_spec_line(terms):
   inVars = []
 
   while True:
-    (cTok,outArr) = parse_exo_compute_array(terms,cTok)
+    (cTok,outArr) = parse_array(terms,cTok)
     inVars.append(outArr)
 
     if terms[cTok] == "]":
@@ -996,12 +998,46 @@ def parse_exo_compute_spec_line(terms):
   assert terms[cTok] == "OUTPUTS"
   cTok += 1
 
-  (cTok,outVars) = parse_exo_compute_array(terms,cTok)
+  (cTok,outVars) = parse_array(terms,cTok)
 
   return (inVars,outVars,exoId)
 
+def parse_ext_gadget_spec_line(terms):
+  cTok = 0
+  assert terms[cTok] == "EXT_GADGET"
+  cTok += 1
+
+  assert terms[cTok] == "GADGETID"
+  cTok += 1
+
+  gadgetId = int(terms[cTok])
+  cTok += 1
+
+  assert terms[cTok] == "INPUTS"
+  cTok += 1
+
+  (cTok,inVars) = parse_array(terms,cTok)
+  
+  assert terms[cTok] == "OUTPUTS"
+  cTok += 1
+
+  (cTok,outVars) = parse_array(terms,cTok)
+  
+  assert terms[cTok] == "INTERMEDIATE"
+  cTok += 1
+  
+  numIntermediate = int(terms[cTok])
+  intermediateVars = map(lambda i: "G{}V{}".format(gadgetId, i), range(0, numIntermediate))
+
+  return (inVars,outVars,intermediateVars,gadgetId)
+
+def parse_ext_gadget_pws_line(line):
+  terms = collections.deque(line.split())
+  (inVars,outVars,intermediateVars,gadgetId) = parse_ext_gadget_spec_line(terms)
+  return (inVars + outVars + intermediateVars, gadgetId)
+
 # parse a single array, like [ a b c d ]
-def parse_exo_compute_array(terms,cTok):
+def parse_array(terms,cTok):
   theArr = []
 
   assert terms[cTok] == "["
@@ -1509,7 +1545,6 @@ metric_num_Nz(C) %s %d
 def convert_to_compressed_polynomial(j, polynomial, shuffled_indices):
 #   num_inputs = input_vars.num_vars #count_lines(text, INPUT_TAG)
 #   num_outputs = output_vars.num_vars #count_lines(text, OUTPUT_TAG)
-  num_vars = variables.num_vars # count_lines(text, VARIABLES_TAG)
 
   i = -1
   coefficient = 0
@@ -1530,16 +1565,20 @@ def convert_to_compressed_polynomial(j, polynomial, shuffled_indices):
         coefficient = term
     else:
       (coefficient, variable) = term.split(" * ")
-      index = int(variable[1:]) #remove the first character and store in index
-      if (variable.startswith("V")):
-        i = 1 + shuffled_indices[index]
-      elif (variable.startswith("I")):
-        i = 1 + num_vars + index
-      elif (variable.startswith("O")):
-        i = 1 + num_vars + index
-
+      i = convert_variable_to_index(variable, shuffled_indices)
     entries += ["%d %d %s\n" % (i, j, coefficient)]
   return "".join(entries)
+
+def convert_variable_to_index(varName, shuffled_indices):
+  num_vars = variables.num_vars # count_lines(text, VARIABLES_TAG)
+  originalIndex = int(varName[1:]) #remove the first character and store in index
+  if (varName.startswith("V")):
+    index = 1 + shuffled_indices[originalIndex]
+  elif (varName.startswith("I")):
+    index = 1 + num_vars + originalIndex
+  elif (varName.startswith("O")):
+    index = 1 + num_vars + originalIndex
+  return index
 
 def append_files(fp, file_name_to_append):
   with open(file_name_to_append) as file_object:
@@ -1632,6 +1671,38 @@ def generate_zaatar_matrices(spec_file, shuffled_indices, qap_file_name):
       NzA += cons_entry.Aij
       NzB += cons_entry.Bij
       NzC += cons_entry.Cij
+    if line.startswith("EXT_GADGET"):
+      (varList, gadgetId) = parse_ext_gadget_pws_line(line)
+
+      # Try calling into gadget binary
+      try:
+        cmd = ["../../pepper/bin/gadget{}".format(gadgetId), "constraints"]
+        p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+      except OSError as e:
+        raise RuntimeError("{}\n\nDoes bin/gadget{} exist?\n".format(e, gadgetId))
+      
+      # Parse output of gadget binary
+      for outLine in iter(p.stdout.readline, b''):
+        try:
+          constraints = json.loads(outLine)
+          assert len(constraints) == 3
+        except Exception as e:
+          raise RuntimeError('''{}\n\nDoes `bin/gadget{} constraints` output the correct format?
+Expecting `[{{aIndex: aValue, ...}}, {{bIndex: bValue, ...}}, {{cIndex: cValue, ...}}]`
+          '''.format(e, gadgetId))
+        
+        # Insert constraints into matrices
+        for matrix, out in {0: fp_matrix_a, 1: fp_matrix_b, 2: fp_matrix_c}.iteritems():
+          for index, value in constraints[matrix].iteritems():
+            index  = int(index)
+            # remap index to correct variable name, unless it's 0 (meaning constant 1)
+            if index != 0:
+              (_, varName) = to_var(varList[index-1])
+              index = convert_variable_to_index(varName, shuffled_indices)
+            out.write("{} {} {}".format(index, j, value))
+            
+        j = j + 1
+        num_constraints = num_constraints + 1
     else:
       # variable names are directly used in to_basic_constraints.
       # numbering are performed in expand_polynomial_matrixrow.
@@ -2184,6 +2255,26 @@ def generate_computation_exo_compute(terms, pws_file):
 
   pws_file.write(" ".join(newLine) + "\n")
 
+def generate_computation_ext_gadget(terms, pws_file):
+  (inVars, outVars, intermediateVars, gadgetId) = parse_ext_gadget_spec_line(terms)
+  
+  def snd(tup):
+    return tup[1]
+
+  newLine = []
+  newLine.append("EXT_GADGET GADGETID %d INPUTS [" % gadgetId)
+
+  newLine += map(snd,map(to_var,inVars));
+  newLine.append("] OUTPUTS [")
+
+  newLine += map(snd,map(to_var,outVars));
+  newLine.append("] INTERMEDIATE [")
+
+  newLine += map(snd,map(to_var,intermediateVars));
+  newLine.append("]")
+  
+  pws_file.write(" ".join(newLine) + "\n")
+
 def generate_computation_mem_consistency(terms, pws_file):
   (address_width, width, input) = parse_mem_consistency_spec_line(terms)
   # expand constraints to compute the actual input to the benes network.
@@ -2293,6 +2384,8 @@ def generate_computation_line(line, pws_file):
     generate_computation_mem_consistency(terms, pws_file)
   elif line.startswith("EXO_COMPUTE"):
     generate_computation_exo_compute(terms, pws_file)
+  elif line.startswith("EXT_GADGET"):
+    generate_computation_ext_gadget(terms, pws_file)
   else:
     # Depends on whether we have zaatar or ginger constraints
     global framework

--- a/compiler/frontend/src/SFE/Compiler/CompiledStatement.java
+++ b/compiler/frontend/src/SFE/Compiler/CompiledStatement.java
@@ -281,12 +281,14 @@ public class CompiledStatement extends Statement {
 	static class ParsedExtGadget {
 		final int gadgetId;
 		final int intermediateVarCount;
+		final long intermediateVarOffset;
         final List<String> inVarsStr;
 		final List<String> outVarsStr;
 
-        ParsedExtGadget(String gadgetIdStr, List<String> inVarsStr, List<String> outVarsStr, String intermediateVarCountStr) {
+        ParsedExtGadget(String gadgetIdStr, List<String> inVarsStr, List<String> outVarsStr, String intermediateVarCountStr, String intermediateVarOffsetStr) {
 			this.gadgetId = Integer.parseInt(gadgetIdStr);
 			this.intermediateVarCount = Integer.parseInt(intermediateVarCountStr);
+			this.intermediateVarOffset = Long.parseLong(intermediateVarOffsetStr);
             this.inVarsStr = inVarsStr;
 			this.outVarsStr = outVarsStr;
         }
@@ -358,6 +360,9 @@ public class CompiledStatement extends Statement {
 		parseCheckInput(in,"INTERMEDIATE");
 		final String intermediateVarCountStr = in.next();
 
+		parseCheckInput(in,"OFFSET");
+		final String intermediateVarOffsetStr = in.next();
+
         // comment
         parseCheckInput(in,"//");
         parseCheckInput(in,"ext_gadget");
@@ -366,7 +371,7 @@ public class CompiledStatement extends Statement {
 		parseCheckInput(in,"outVars="+Integer.toString(outVarsStr.size()));
 		parseCheckInput(in,"intermediateVars="+intermediateVarCountStr);
 
-        return new ParsedExtGadget(gadgetIdStr,inVarsStr,outVarsStr,intermediateVarCountStr);
+        return new ParsedExtGadget(gadgetIdStr,inVarsStr,outVarsStr,intermediateVarCountStr,intermediateVarOffsetStr);
 	}
 	
     private void parseExoComputeLine(int varNum, ReferenceProfile rp,

--- a/compiler/frontend/src/SFE/Compiler/CompiledStatement.java
+++ b/compiler/frontend/src/SFE/Compiler/CompiledStatement.java
@@ -109,14 +109,14 @@ public class CompiledStatement extends Statement {
 			parseSplitLine(varNum, rp, in, assignments);
 			return;
 		}
-        if (type.equals(CBuiltinFunctions.EXO_COMPUTE_NAME)) {
-            parseExoComputeLine(varNum, rp, in, assignments);
-            return;
+		if (type.equals(CBuiltinFunctions.EXO_COMPUTE_NAME)) {
+			parseExoComputeLine(varNum, rp, in, assignments);
+			return;
 		}
 		if (type.equals(CBuiltinFunctions.EXT_GADGET_NAME)) {
-            parseExtGadgetLine(varNum, rp, in, assignments);
-            return;
-        }
+			parseExtGadgetLine(varNum, rp, in, assignments);
+			return;
+		}
 		if (type.equals(CBuiltinFunctions.RAMPUT_ENHANCED_NAME)) {
 			parseRamPutEnhancedLine(varNum, rp, in, assignments);
 			return;
@@ -266,94 +266,94 @@ public class CompiledStatement extends Statement {
 		ss.toAssignmentStatements_NoChangeRef(assignments);
 	}
 
-    static class ParsedExoCompute {
-        final int exoId;
-        final List<List<String>> inVarsStr;
-        final List<String> outVarsStr;
+	static class ParsedExoCompute {
+		final int exoId;
+		final List<List<String>> inVarsStr;
+		final List<String> outVarsStr;
 
-        ParsedExoCompute(String exoIdStr, List<List<String>> inVarsStr, List<String> outVarsStr) {
-            this.exoId = Integer.parseInt(exoIdStr);
-            this.inVarsStr = inVarsStr;
-            this.outVarsStr = outVarsStr;
-        }
+		ParsedExoCompute(String exoIdStr, List<List<String>> inVarsStr, List<String> outVarsStr) {
+			this.exoId = Integer.parseInt(exoIdStr);
+			this.inVarsStr = inVarsStr;
+			this.outVarsStr = outVarsStr;
+		}
 	}
 	
 	static class ParsedExtGadget {
 		final int gadgetId;
 		final int intermediateVarCount;
 		final long intermediateVarOffset;
-        final List<String> inVarsStr;
+		final List<String> inVarsStr;
 		final List<String> outVarsStr;
 
-        ParsedExtGadget(String gadgetIdStr, List<String> inVarsStr, List<String> outVarsStr, String intermediateVarCountStr, String intermediateVarOffsetStr) {
+		ParsedExtGadget(String gadgetIdStr, List<String> inVarsStr, List<String> outVarsStr, String intermediateVarCountStr, String intermediateVarOffsetStr) {
 			this.gadgetId = Integer.parseInt(gadgetIdStr);
 			this.intermediateVarCount = Integer.parseInt(intermediateVarCountStr);
 			this.intermediateVarOffset = Long.parseLong(intermediateVarOffsetStr);
-            this.inVarsStr = inVarsStr;
+			this.inVarsStr = inVarsStr;
 			this.outVarsStr = outVarsStr;
-        }
-    }
+		}
+	}
 
-    // this lets us use the parser for Dependency Profiling where we're working over an array rather than a Scanner
-    static class ArrayIterator<E> implements Iterator<E> {
-        private final E[] in;
-        private int idx;
+	// this lets us use the parser for Dependency Profiling where we're working over an array rather than a Scanner
+	static class ArrayIterator<E> implements Iterator<E> {
+		private final E[] in;
+		private int idx;
 
-        ArrayIterator ( E[] in , int...idx ) {
-            this.in = in;
-            if (idx.length > 0) { this.idx = idx[0]; }
-            else { this.idx = 0; }
-        }
+		ArrayIterator ( E[] in , int...idx ) {
+			this.in = in;
+			if (idx.length > 0) { this.idx = idx[0]; }
+			else { this.idx = 0; }
+		}
 
-        public boolean hasNext() { return in.length > idx; }
-        public E next() { return in[idx++]; }
-        public void remove() { throw new UnsupportedOperationException("ArrayIterator does not support remove."); }
-    }
+		public boolean hasNext() { return in.length > idx; }
+		public E next() { return in[idx++]; }
+		public void remove() { throw new UnsupportedOperationException("ArrayIterator does not support remove."); }
+	}
 
-    static ParsedExoCompute exoComputeParser(Iterator<String> in) {
-        parseCheckInput(in,"EXOID");
+	static ParsedExoCompute exoComputeParser(Iterator<String> in) {
+		parseCheckInput(in,"EXOID");
 
-        // id#
-        final String exoIdStr = in.next();
+		// id#
+		final String exoIdStr = in.next();
 
-        parseCheckInput(in,"INPUTS");
-        parseCheckInput(in,"[");
+		parseCheckInput(in,"INPUTS");
+		parseCheckInput(in,"[");
 
-        // input variables
-        final List<List<String>> inVarsStr = parseEL(in);
+		// input variables
+		final List<List<String>> inVarsStr = parseEL(in);
 
-        parseCheckInput(in,"OUTPUTS");
-        parseCheckInput(in,"[");
+		parseCheckInput(in,"OUTPUTS");
+		parseCheckInput(in,"[");
 
-        // output variables
-        final List<String> outVarsStr = parseL(in);
+		// output variables
+		final List<String> outVarsStr = parseL(in);
 
-        // comment
-        parseCheckInput(in,"//");
-        parseCheckInput(in,"exo_compute");
-        parseCheckInput(in,"#"+exoIdStr);
-        parseCheckInput(in,"inVectors="+Integer.toString(inVarsStr.size()));
-        parseCheckInput(in,"outVars="+Integer.toString(outVarsStr.size()));
+		// comment
+		parseCheckInput(in,"//");
+		parseCheckInput(in,"exo_compute");
+		parseCheckInput(in,"#"+exoIdStr);
+		parseCheckInput(in,"inVectors="+Integer.toString(inVarsStr.size()));
+		parseCheckInput(in,"outVars="+Integer.toString(outVarsStr.size()));
 
-        return new ParsedExoCompute(exoIdStr,inVarsStr,outVarsStr);
+		return new ParsedExoCompute(exoIdStr,inVarsStr,outVarsStr);
 	}
 
 	static ParsedExtGadget extGadgetParser(Iterator<String> in) {
-        parseCheckInput(in,"GADGETID");
+		parseCheckInput(in,"GADGETID");
 
-        // id#
-        final String gadgetIdStr = in.next();
+		// id#
+		final String gadgetIdStr = in.next();
 
-        parseCheckInput(in,"INPUTS");
-        parseCheckInput(in,"[");
+		parseCheckInput(in,"INPUTS");
+		parseCheckInput(in,"[");
 
-        // input variables
-        final List<String> inVarsStr = parseL(in);
+		// input variables
+		final List<String> inVarsStr = parseL(in);
 
-        parseCheckInput(in,"OUTPUTS");
-        parseCheckInput(in,"[");
+		parseCheckInput(in,"OUTPUTS");
+		parseCheckInput(in,"[");
 
-        // output variables
+		// output variables
 		final List<String> outVarsStr = parseL(in);
 		
 		// intermediate variables
@@ -363,105 +363,105 @@ public class CompiledStatement extends Statement {
 		parseCheckInput(in,"OFFSET");
 		final String intermediateVarOffsetStr = in.next();
 
-        // comment
-        parseCheckInput(in,"//");
-        parseCheckInput(in,"ext_gadget");
-        parseCheckInput(in,"#"+gadgetIdStr);
-        parseCheckInput(in,"inVectors="+Integer.toString(inVarsStr.size()));
+		// comment
+		parseCheckInput(in,"//");
+		parseCheckInput(in,"ext_gadget");
+		parseCheckInput(in,"#"+gadgetIdStr);
+		parseCheckInput(in,"inVectors="+Integer.toString(inVarsStr.size()));
 		parseCheckInput(in,"outVars="+Integer.toString(outVarsStr.size()));
 		parseCheckInput(in,"intermediateVars="+intermediateVarCountStr);
 
-        return new ParsedExtGadget(gadgetIdStr,inVarsStr,outVarsStr,intermediateVarCountStr,intermediateVarOffsetStr);
+		return new ParsedExtGadget(gadgetIdStr,inVarsStr,outVarsStr,intermediateVarCountStr,intermediateVarOffsetStr);
 	}
 	
-    private void parseExoComputeLine(int varNum, ReferenceProfile rp,
-            Scanner in, StatementBuffer assignments) {
+	private void parseExoComputeLine(int varNum, ReferenceProfile rp,
+			Scanner in, StatementBuffer assignments) {
 
-        // parse the line
-        final ParsedExoCompute p = exoComputeParser(in);
+		// parse the line
+		final ParsedExoCompute p = exoComputeParser(in);
 
-        // parse input and output variable numbers into variables
-        final List<List<LvalExpression>> inVars = findVarsLL(p.inVarsStr);
-        final List<LvalExpression> outVars = findVarsL(p.outVarsStr);
+		// parse input and output variable numbers into variables
+		final List<List<LvalExpression>> inVars = findVarsLL(p.inVarsStr);
+		final List<LvalExpression> outVars = findVarsL(p.outVarsStr);
 
-        Program.resetCounter(varNum);   // force next statement to have the correct line number
-        final ExoComputeStatement exo = new ExoComputeStatement(inVars,outVars,p.exoId);
-        exo.toAssignmentStatements_NoChangeRef(assignments);
+		Program.resetCounter(varNum);   // force next statement to have the correct line number
+		final ExoComputeStatement exo = new ExoComputeStatement(inVars,outVars,p.exoId);
+		exo.toAssignmentStatements_NoChangeRef(assignments);
 	}
 	
 	private void parseExtGadgetLine(int varNum, ReferenceProfile rp,
-            Scanner in, StatementBuffer assignments) {
+			Scanner in, StatementBuffer assignments) {
 
-        // parse the line
-        final ParsedExtGadget p = extGadgetParser(in);
+		// parse the line
+		final ParsedExtGadget p = extGadgetParser(in);
 
-        // parse input and output variable numbers into variables
-        final List<LvalExpression> inVars = findVarsL(p.inVarsStr);
-        final List<LvalExpression> outVars = findVarsL(p.outVarsStr);
+		// parse input and output variable numbers into variables
+		final List<LvalExpression> inVars = findVarsL(p.inVarsStr);
+		final List<LvalExpression> outVars = findVarsL(p.outVarsStr);
 
-        Program.resetCounter(varNum);   // force next statement to have the correct line number
-        final ExtGadgetStatement gadget = new ExtGadgetStatement(inVars,outVars,p.gadgetId);
-        gadget.toAssignmentStatements_NoChangeRef(assignments);
-    }
+		Program.resetCounter(varNum);   // force next statement to have the correct line number
+		final ExtGadgetStatement gadget = new ExtGadgetStatement(inVars,outVars,p.gadgetId);
+		gadget.toAssignmentStatements_NoChangeRef(assignments);
+	}
 
-    // find vars corresponding to each element in a list
-    private List<LvalExpression> findVarsL(List<String> thisL) {
-        final List<LvalExpression> outL = new ArrayList<LvalExpression>(thisL.size());
-        for (String s : thisL) {
-            final LvalExpression iExp = varByNumber.get(Integer.parseInt(s));
-            if (null == iExp) {
-                throw new RuntimeException("Could not find variable " + s + " for exo_compute/ext_gadget input.");
-            }
-            outL.add(iExp);
-        }
-        return outL;
-    }
+	// find vars corresponding to each element in a list
+	private List<LvalExpression> findVarsL(List<String> thisL) {
+		final List<LvalExpression> outL = new ArrayList<LvalExpression>(thisL.size());
+		for (String s : thisL) {
+			final LvalExpression iExp = varByNumber.get(Integer.parseInt(s));
+			if (null == iExp) {
+				throw new RuntimeException("Could not find variable " + s + " for exo_compute/ext_gadget input.");
+			}
+			outL.add(iExp);
+		}
+		return outL;
+	}
 
-    // find vars in each element of a list of lists
-    private List<List<LvalExpression>> findVarsLL(List<List<String>> thisLL) {
-        final List<List<LvalExpression>> outLL = new ArrayList<List<LvalExpression>>(thisLL.size());
-        for (List<String> thisL : thisLL) {
-            outLL.add(findVarsL(thisL));
-        }
-        return outLL;
-    }
+	// find vars in each element of a list of lists
+	private List<List<LvalExpression>> findVarsLL(List<List<String>> thisLL) {
+		final List<List<LvalExpression>> outLL = new ArrayList<List<LvalExpression>>(thisLL.size());
+		for (List<String> thisL : thisLL) {
+			outLL.add(findVarsL(thisL));
+		}
+		return outLL;
+	}
 
-    private static void parseCheckInput(Iterator<String> in, String expected) {
-        final String nxt = in.next();
+	private static void parseCheckInput(Iterator<String> in, String expected) {
+		final String nxt = in.next();
 
-        if (! expected.equals(nxt)) {
-            throw new RuntimeException("Expected " + expected + ", got " + nxt + ".");
-        }
-    }
+		if (! expected.equals(nxt)) {
+			throw new RuntimeException("Expected " + expected + ", got " + nxt + ".");
+		}
+	}
 
-    private static List<String> parseL(Iterator<String> in) {
-        final List<String> outL = new ArrayList<String>();
-        while (true) {
-            final String nxt = in.next();
-            if ("]".equals(nxt)) {
-                break;
-            } else {
-                outL.add(nxt);
-            }
-        }
-        return outL;
-    }
+	private static List<String> parseL(Iterator<String> in) {
+		final List<String> outL = new ArrayList<String>();
+		while (true) {
+			final String nxt = in.next();
+			if ("]".equals(nxt)) {
+				break;
+			} else {
+				outL.add(nxt);
+			}
+		}
+		return outL;
+	}
 
-    private static List<List<String>> parseEL(Iterator<String> in) {
-        final List<List<String>> outList = new ArrayList<List<String>>();
-        while (true) {
-            final String nxt = in.next();
-            if ("]".equals(nxt)) {
-                break;
-            } else if (! "[".equals(nxt)) {
-                throw new RuntimeException("Expected [ or ] in parseEL, got " + nxt + ".");
-            }
+	private static List<List<String>> parseEL(Iterator<String> in) {
+		final List<List<String>> outList = new ArrayList<List<String>>();
+		while (true) {
+			final String nxt = in.next();
+			if ("]".equals(nxt)) {
+				break;
+			} else if (! "[".equals(nxt)) {
+				throw new RuntimeException("Expected [ or ] in parseEL, got " + nxt + ".");
+			}
 
-            outList.add(parseL(in));
-        }
+			outList.add(parseL(in));
+		}
 
-        return outList;
-    }
+		return outList;
+	}
 
 	private void parseRamGetEnhancedLine(int varNum, ReferenceProfile rp,
 			Scanner in, StatementBuffer assignments) {

--- a/compiler/frontend/src/SFE/Compiler/ConstraintWriter.java
+++ b/compiler/frontend/src/SFE/Compiler/ConstraintWriter.java
@@ -48,26 +48,26 @@ public class ConstraintWriter {
 		outputVariables = new TreeSet<Integer>();
 		int uniquifier = 0;
 
-        // exoCompute output variables; we use this to hold comments and to check that we've found them all
-        final HashMap<String, Boolean> exOutputs = new HashMap<String, Boolean>();
+		// exoCompute output variables; we use this to hold comments and to check that we've found them all
+		final HashMap<String, Boolean> exOutputs = new HashMap<String, Boolean>();
 
-        // first pass - look for exo_compute/ext_gadget statements and gather up
-        // their output variables so that we can convert them to normal
-        // variables
-        // think: nondeterministic inputs aren't inputs from the circuit POV
-        // but they are behaviorally. So until now we have treated them as
-        // inputs, but now we convert them to normal variables
-        {
-            final BufferedReader br = new BufferedReader(new FileReader(circuitFile));
+		// first pass - look for exo_compute/ext_gadget statements and gather up
+		// their output variables so that we can convert them to normal
+		// variables
+		// think: nondeterministic inputs aren't inputs from the circuit POV
+		// but they are behaviorally. So until now we have treated them as
+		// inputs, but now we convert them to normal variables
+		{
+			final BufferedReader br = new BufferedReader(new FileReader(circuitFile));
 
-            String line = null;
-            while ((line = br.readLine()) != null) {
+			String line = null;
+			while ((line = br.readLine()) != null) {
 				// greater than zero because we know there's a line number and a space first!
 				boolean isExoCompute = line.indexOf(CBuiltinFunctions.EXO_COMPUTE_NAME) > 0;
 				boolean isExtGadget = line.indexOf(CBuiltinFunctions.EXT_GADGET_NAME) > 0;
-                if (isExoCompute || isExtGadget) {
-                    final Scanner in = new Scanner(line);
-                    final String lineNo = in.next();
+				if (isExoCompute || isExtGadget) {
+					final Scanner in = new Scanner(line);
+					final String lineNo = in.next();
 					in.next();  // CBuiltinFunctions.EXO_COMPUTE_NAME or EXT_GADGET_NAME
 					
 					List<String> outVars;
@@ -79,18 +79,18 @@ public class ConstraintWriter {
 						outVars = p.outVarsStr;
 					}
 
-                    for (String s : outVars) {
-                        if (null != exOutputs.get(s)) {
-                            throw new RuntimeException("Error: two EXO_COMPUTE or EXT_GADGET statements write the same variable.");
-                        }
-                        exOutputs.put(s,true);   // for now, just put in a dummy string, we'll fill this in in the next pass
-                    }
-                }
-            }
-        }
+					for (String s : outVars) {
+						if (null != exOutputs.get(s)) {
+							throw new RuntimeException("Error: two EXO_COMPUTE or EXT_GADGET statements write the same variable.");
+						}
+						exOutputs.put(s,true);   // for now, just put in a dummy string, we'll fill this in in the next pass
+					}
+				}
+			}
+		}
 
-        // second pass, input variables
-        // skip exo_compute outputs here; they're not actually circuit inputs
+		// second pass, input variables
+		// skip exo_compute outputs here; they're not actually circuit inputs
 		{
 			BufferedReader bufferedreader = new BufferedReader(new FileReader(
 					circuitFile));
@@ -104,13 +104,13 @@ public class ConstraintWriter {
 				}
 				int varNum = new Integer(firstTerm);
 				if (in.next().equals("input")) {
-                    if (null == exOutputs.get(firstTerm)) {
-                        // normal input variable, since it's not in the exOutputs
-                        String comment = line.split("//")[1];
-                        inputVariables.put(varNum, comment);
-                        String variableName = "I" + varNum;
-                        out.println(variableName + " //" + comment);
-                    }
+					if (null == exOutputs.get(firstTerm)) {
+						// normal input variable, since it's not in the exOutputs
+						String comment = line.split("//")[1];
+						inputVariables.put(varNum, comment);
+						String variableName = "I" + varNum;
+						out.println(variableName + " //" + comment);
+					}
 				}
 			}
 			out.println("END_INPUT");
@@ -119,7 +119,7 @@ public class ConstraintWriter {
 
 		out.println();
 
-        // third pass - output variables
+		// third pass - output variables
 		{
 			BufferedReader bufferedreader = new BufferedReader(new FileReader(
 					circuitFile));
@@ -151,7 +151,7 @@ public class ConstraintWriter {
 
 		out.println();
 
-        // fourth pass - internal variables
+		// fourth pass - internal variables
 		{
 			BufferedReader bufferedreader = new BufferedReader(new FileReader(
 					circuitFile));
@@ -238,21 +238,21 @@ public class ConstraintWriter {
 					// Do nothing.
 				} else {
 					if (!inputVariables.containsKey(varNum) && !outputVariables.contains(varNum)) {
-                        // this might fail silently, but that's OK, we check later that we got them all
-                        exOutputs.remove(firstTerm);
+						// this might fail silently, but that's OK, we check later that we got them all
+						exOutputs.remove(firstTerm);
 
 						String variableName = "V" + varNum;
 						out.println(variableName + " //" + line.split("//")[1]);
 					} else {
-                        // input and output variables already taken care of
+						// input and output variables already taken care of
 					}
 				}
 			}
 			out.println("END_VARIABLES");
 			bufferedreader.close();
 
-            assert exOutputs.size() == 0 :
-                "exOutputs has remaining elements, indicating that we failed to add all its contents to the VARIABLES list.";
+			assert exOutputs.size() == 0 :
+				"exOutputs has remaining elements, indicating that we failed to add all its contents to the VARIABLES list.";
 
 			// Print to stdout the op counts:
 			for (Entry<String, Integer> entry : operation_counts.entrySet()) {
@@ -294,7 +294,7 @@ public class ConstraintWriter {
 					}
 					out.println();
 				} else {
-                    compileConstraintsLine(line);
+					compileConstraintsLine(line);
 				}
 			}
 			out.println("END_CONSTRAINTS");
@@ -352,7 +352,7 @@ public class ConstraintWriter {
 		Scanner in = new Scanner(line);
 
 		in = new Scanner(line);
-        String varNumStr = in.next();
+		String varNumStr = in.next();
 		int varNum = Integer.parseInt(varNumStr);
 		String variableName = getConstraintVarName(varNum);
 		String type = in.next();
@@ -371,14 +371,14 @@ public class ConstraintWriter {
 				// } else if (gateType.equals("getdb")){
 				// compileGetDbConstraint(variableName, in);
 			} else {
-                // first check if this poly constraint is one of the spurious
-                // assignments we inserted into the circuit in order to make a
-                // placeholder variable for the exo_compute output
-                compilePolyConstraint(variableName, in);
+				// first check if this poly constraint is one of the spurious
+				// assignments we inserted into the circuit in order to make a
+				// placeholder variable for the exo_compute output
+				compilePolyConstraint(variableName, in);
 			}
 		} else if (type.equals("split")) {
 			compileSplitConstraint(in);
-        } else if (type.equals(CBuiltinFunctions.EXO_COMPUTE_NAME)) {
+		} else if (type.equals(CBuiltinFunctions.EXO_COMPUTE_NAME)) {
 			compileExoComputeConstraint(in);
 		} else if (type.equals(CBuiltinFunctions.EXT_GADGET_NAME)) {
 			compileExtGadgetConstraint(in);
@@ -621,22 +621,22 @@ public class ConstraintWriter {
 				+ addrs + " NUM_Y " + num_bits + " Y " + value);
 	}
 
-    private void compileExoComputeConstraint(Scanner in) {
-        // parse the line
-        final CompiledStatement.ParsedExoCompute p = CompiledStatement.exoComputeParser(in);
+	private void compileExoComputeConstraint(Scanner in) {
+		// parse the line
+		final CompiledStatement.ParsedExoCompute p = CompiledStatement.exoComputeParser(in);
 
-        if (in.hasNextLine()) {
-            in.nextLine();
-        }
+		if (in.hasNextLine()) {
+			in.nextLine();
+		}
 
-        // then just print the same damn thing out again
-        out.print(CBuiltinFunctions.EXO_COMPUTE_NAME.toUpperCase() + " EXOID " + Integer.toString(p.exoId) + " INPUTS [ ");
-        compileLL(p.inVarsStr);
+		// then just print the same damn thing out again
+		out.print(CBuiltinFunctions.EXO_COMPUTE_NAME.toUpperCase() + " EXOID " + Integer.toString(p.exoId) + " INPUTS [ ");
+		compileLL(p.inVarsStr);
 
-        out.print("] OUTPUTS [ ");
-        compileL(p.outVarsStr);
+		out.print("] OUTPUTS [ ");
+		compileL(p.outVarsStr);
 
-        out.println("]");
+		out.println("]");
 	}
 	
 	private void compileExtGadgetConstraint(Scanner in) {
@@ -648,27 +648,27 @@ public class ConstraintWriter {
 		}
 
 		out.print(CBuiltinFunctions.EXT_GADGET_NAME.toUpperCase() + " GADGETID " + Integer.toString(p.gadgetId) + " INPUTS [ ");
-        compileL(p.inVarsStr);
+		compileL(p.inVarsStr);
 
-        out.print("] OUTPUTS [ ");
-        compileL(p.outVarsStr);
+		out.print("] OUTPUTS [ ");
+		compileL(p.outVarsStr);
 
 		out.println("] INTERMEDIATE " + p.intermediateVarCount + " OFFSET " + p.intermediateVarOffset);
 	}
 
-    private void compileL(List<String> inL) {
-        for (String s : inL) {
-            out.print(getConstraintVarName(Integer.parseInt(s)) + " ");
-        }
-    }
+	private void compileL(List<String> inL) {
+		for (String s : inL) {
+			out.print(getConstraintVarName(Integer.parseInt(s)) + " ");
+		}
+	}
 
-    private void compileLL(List<List<String>> inL) {
-        for (List<String> thisL : inL) {
-            out.print("[ ");
-            compileL(thisL);
-            out.print("] ");
-        }
-    }
+	private void compileLL(List<List<String>> inL) {
+		for (List<String> thisL : inL) {
+			out.print("[ ");
+			compileL(thisL);
+			out.print("] ");
+		}
+	}
 
 	private void compileRAMPutEnhancedConstraint(Scanner in) {
 		String retVar = getConstraintTerm(in.next());

--- a/compiler/frontend/src/SFE/Compiler/ConstraintWriter.java
+++ b/compiler/frontend/src/SFE/Compiler/ConstraintWriter.java
@@ -227,7 +227,7 @@ public class ConstraintWriter {
 					if (type.equals(CBuiltinFunctions.EXT_GADGET_NAME)) {
 						// print intermediate variables for ext_gadget
 						final CompiledStatement.ParsedExtGadget p = CompiledStatement.extGadgetParser(in);
-						for (int i = 0; i < p.intermediateVarCount; i++) {
+						for (long i = p.intermediateVarOffset; i < p.intermediateVarOffset + p.intermediateVarCount; i++) {
 							out.println("G" + p.gadgetId + "V" + i + " //" + line.split("//")[1]);
 						}
 					}
@@ -653,7 +653,7 @@ public class ConstraintWriter {
         out.print("] OUTPUTS [ ");
         compileL(p.outVarsStr);
 
-		out.println("] INTERMEDIATE " + p.intermediateVarCount);
+		out.println("] INTERMEDIATE " + p.intermediateVarCount + " OFFSET " + p.intermediateVarOffset);
 	}
 
     private void compileL(List<String> inL) {

--- a/compiler/frontend/src/SFE/Compiler/DependencyProfile.java
+++ b/compiler/frontend/src/SFE/Compiler/DependencyProfile.java
@@ -46,7 +46,7 @@ public class DependencyProfile {
 		try {
 			// Construct the BufferedReader object
 			BufferedReader bufferedReader = new BufferedReader(new FileReader(
-			    circuitBackwards));
+				circuitBackwards));
 
 			PrintWriter out = new PrintWriter(outFile);
 			String line = null;
@@ -77,7 +77,7 @@ public class DependencyProfile {
 	private static int lastPrint = 0;
 
 	private void parseAssignment(String line, PrintWriter out,
-	    Set<String> outputVariables, Map<Integer, int[]> refDatas) {
+		Set<String> outputVariables, Map<Integer, int[]> refDatas) {
 		String[] in = wspace.split(line);
 		int in_p = 0;
 		String firstTerm = in[in_p++];
@@ -93,9 +93,9 @@ public class DependencyProfile {
 		String type = in[in_p++];
 		if (type.equals("input")) {
 			out.printf("%d 1 0 -1 -1\n", lineNumber); // This line is used, it is not
-			                                          // output, reference count and
-			                                          // kill points don't matter for
-			                                          // input lines
+													  // output, reference count and
+													  // kill points don't matter for
+													  // input lines
 		} else if (type.equals("split")) {
 			// Read output lines
 			int[] ref = new int[2];
@@ -142,24 +142,24 @@ public class DependencyProfile {
 				// Emit statement
 				// Print out this line
 				out.printf("%d 1 %d %d %d\n", lineNumber, 0, // split statement is never
-				                                             // output.
-				    ref[0], ref[1]); // This line is used, it may be output output ref
-				                     // count and kill point
+															 // output.
+					ref[0], ref[1]); // This line is used, it may be output output ref
+									 // count and kill point
 			}
 		} else {
 			boolean output = false;
 			if (type.equals("output")) {
 				// We only want the final assignment to output variables.
 				String varName = wspace
-				    .split(line.substring(line.indexOf("//") + 2), 2)[0];
+					.split(line.substring(line.indexOf("//") + 2), 2)[0];
 				if (!outputVariables.contains(varName)) {
 					outputVariables.add(varName);
 					output = true;
 					// Ensure that the variable is referenced.
 					if (!refDatas.containsKey(lineNumber)) {
 						refDatas.put(lineNumber, new int[] { 1, Integer.MAX_VALUE }); // Reference
-						                                                              // from
-						                                                              // infinity
+																					  // from
+																					  // infinity
 					}
 				}
 			}
@@ -167,15 +167,15 @@ public class DependencyProfile {
 			// Don't remove RAMPUTs, HASHFREEs, or ASSERT_ZEROs, these never have
 			// referencers but they must be preserved.
 			if (type.equals(CBuiltinFunctions.RAMPUT_NAME)
-			    || type.equals(CBuiltinFunctions.ASSERT_ZERO_NAME)
-			    || type.equals(CBuiltinFunctions.HASHFREE_NAME)
-			    || type.equals("printf")) {
+				|| type.equals(CBuiltinFunctions.ASSERT_ZERO_NAME)
+				|| type.equals(CBuiltinFunctions.HASHFREE_NAME)
+				|| type.equals("printf")) {
 				if (refDatas.containsKey(lineNumber)) {
 					throw new RuntimeException("Assertion error " + lineNumber);
 				}
 				refDatas.put(lineNumber, new int[] { 1, Integer.MAX_VALUE }); // Reference
-				                                                              // from
-				                                                              // infinity
+																			  // from
+																			  // infinity
 			}
 
 			if (type.equals(CBuiltinFunctions.RAMPUT_ENHANCED_NAME)) {
@@ -183,47 +183,47 @@ public class DependencyProfile {
 					throw new RuntimeException("Assertion error " + lineNumber);
 				}
 				refDatas.put(lineNumber, new int[] { 1, Integer.MAX_VALUE }); // Reference
-				                                                              // from
-				                                                              // infinity
+																			  // from
+																			  // infinity
 			}
 
-            // preserve exo_computes!
-            if (type.equals(CBuiltinFunctions.EXO_COMPUTE_NAME)) {
-                if (refDatas.containsKey(lineNumber)) {
-                    throw new RuntimeException("Assertion error (exo) " + lineNumber);
-                }
-                refDatas.put(lineNumber, new int[] { 1, Integer.MAX_VALUE });   // ref from infty
+			// preserve exo_computes!
+			if (type.equals(CBuiltinFunctions.EXO_COMPUTE_NAME)) {
+				if (refDatas.containsKey(lineNumber)) {
+					throw new RuntimeException("Assertion error (exo) " + lineNumber);
+				}
+				refDatas.put(lineNumber, new int[] { 1, Integer.MAX_VALUE });   // ref from infty
 
-                // parse this whole line so that we can add refs to the inputs and outputs
-                final CompiledStatement.ParsedExoCompute p = CompiledStatement.exoComputeParser(new CompiledStatement.ArrayIterator<String>(in,in_p));
+				// parse this whole line so that we can add refs to the inputs and outputs
+				final CompiledStatement.ParsedExoCompute p = CompiledStatement.exoComputeParser(new CompiledStatement.ArrayIterator<String>(in,in_p));
 
-                // the inputs are referenced by this line, so add a reference as appropriate
-                for (List<String> thisL : p.inVarsStr) {
-                for (String s : thisL) {
-                    final int i = Integer.parseInt(s);
+				// the inputs are referenced by this line, so add a reference as appropriate
+				for (List<String> thisL : p.inVarsStr) {
+				for (String s : thisL) {
+					final int i = Integer.parseInt(s);
 
-                    int[] oldCount = refDatas.get(i);
-                    if (oldCount == null) {
-                        oldCount = new int[] { 1, lineNumber };
-                    } else {
-                        oldCount[0]++;
-                    }
-                    refDatas.put(i, oldCount);
-                }}
+					int[] oldCount = refDatas.get(i);
+					if (oldCount == null) {
+						oldCount = new int[] { 1, lineNumber };
+					} else {
+						oldCount[0]++;
+					}
+					refDatas.put(i, oldCount);
+				}}
 
-                // the outputs should be referenced from infinity so they're never killed
-                // is this a godawful hack? But probably we have to make sure that there is
-                // always a place for the prover to insert its nondeterminism, right?
-                for (String s : p.outVarsStr) {
-                    final int i = Integer.parseInt(s);
-                    refDatas.put(i, new int[] { 1, Integer.MAX_VALUE });
-                }
+				// the outputs should be referenced from infinity so they're never killed
+				// is this a godawful hack? But probably we have to make sure that there is
+				// always a place for the prover to insert its nondeterminism, right?
+				for (String s : p.outVarsStr) {
+					final int i = Integer.parseInt(s);
+					refDatas.put(i, new int[] { 1, Integer.MAX_VALUE });
+				}
 			}
 			
 			// preserve gadgets
 			if (type.equals(CBuiltinFunctions.EXT_GADGET_NAME)) {
 				if (refDatas.containsKey(lineNumber)) {
-                    throw new RuntimeException("Assertion error (gadget) " + lineNumber);
+					throw new RuntimeException("Assertion error (gadget) " + lineNumber);
 				}
 				refDatas.put(lineNumber, new int[] { 1, Integer.MAX_VALUE });   // ref from infty
 
@@ -231,19 +231,19 @@ public class DependencyProfile {
 				final CompiledStatement.ParsedExtGadget p = CompiledStatement.extGadgetParser(new CompiledStatement.ArrayIterator<String>(in,in_p));
 
 				for (String s : p.inVarsStr) {
-                    final int i = Integer.parseInt(s);
-                    refDatas.put(i, new int[] { 1, Integer.MAX_VALUE });
-                }
+					final int i = Integer.parseInt(s);
+					refDatas.put(i, new int[] { 1, Integer.MAX_VALUE });
+				}
 				for (String s : p.outVarsStr) {
-                    final int i = Integer.parseInt(s);
-                    refDatas.put(i, new int[] { 1, Integer.MAX_VALUE });
+					final int i = Integer.parseInt(s);
+					refDatas.put(i, new int[] { 1, Integer.MAX_VALUE });
 				}
 			}
 
 			int[] refs = null;
 			if (type.equals(CBuiltinFunctions.RAMGET_NAME)
-			    || type.equals(CBuiltinFunctions.HASHGET_NAME)
-			    || type.equals(GenericGetStatement.GENERIC_GET_STATEMENT_STR)) {
+				|| type.equals(CBuiltinFunctions.HASHGET_NAME)
+				|| type.equals(GenericGetStatement.GENERIC_GET_STATEMENT_STR)) {
 				refs = getRefDataForAll(in, refDatas, "Y", "]");
 			} else if (type.equals(CBuiltinFunctions.HASHPUT_NAME)) {
 				refs = getRefDataForAll(in, refDatas, "HASH_OUT", "NUM_X");
@@ -259,8 +259,8 @@ public class DependencyProfile {
 			if (refs != null) {
 				// Print out this line
 				out.printf("%d 1 %d %d %d\n", lineNumber, output ? 1 : 0, refs[0],
-				    refs[1]); // This line is used, it may be output output ref count
-				              // and kill point
+					refs[1]); // This line is used, it may be output output ref count
+							  // and kill point
 
 				// Mark all dependencies of the RHS of this assignment statement as used
 				while (true) {
@@ -303,7 +303,7 @@ public class DependencyProfile {
 	 * Note: All tokens between start_after and end must be variables.
 	 */
 	private int[] getRefDataForAll(String[] in, Map<Integer, int[]> refDatas,
-	    String start_after, String end) {
+		String start_after, String end) {
 		// Used if any of the store bits are used
 		int[] refs = null;
 		int in_p = 0;
@@ -326,8 +326,8 @@ public class DependencyProfile {
 				}
 				refs[0] += subRef[0];
 				refs[1] = Math.max(refs[1], subRef[1]); // Keep the whole set until the
-				                                        // last one is no long
-				                                        // referenced.
+														// last one is no long
+														// referenced.
 			}
 		}
 		return refs;

--- a/compiler/frontend/src/SFE/Compiler/DependencyProfile.java
+++ b/compiler/frontend/src/SFE/Compiler/DependencyProfile.java
@@ -218,7 +218,27 @@ public class DependencyProfile {
                     final int i = Integer.parseInt(s);
                     refDatas.put(i, new int[] { 1, Integer.MAX_VALUE });
                 }
-            }
+			}
+			
+			// preserve gadgets
+			if (type.equals(CBuiltinFunctions.EXT_GADGET_NAME)) {
+				if (refDatas.containsKey(lineNumber)) {
+                    throw new RuntimeException("Assertion error (gadget) " + lineNumber);
+				}
+				refDatas.put(lineNumber, new int[] { 1, Integer.MAX_VALUE });   // ref from infty
+
+				// parse this whole line so that we can add refs to the inputs and outputs and intermediate
+				final CompiledStatement.ParsedExtGadget p = CompiledStatement.extGadgetParser(new CompiledStatement.ArrayIterator<String>(in,in_p));
+
+				for (String s : p.inVarsStr) {
+                    final int i = Integer.parseInt(s);
+                    refDatas.put(i, new int[] { 1, Integer.MAX_VALUE });
+                }
+				for (String s : p.outVarsStr) {
+                    final int i = Integer.parseInt(s);
+                    refDatas.put(i, new int[] { 1, Integer.MAX_VALUE });
+				}
+			}
 
 			int[] refs = null;
 			if (type.equals(CBuiltinFunctions.RAMGET_NAME)

--- a/compiler/frontend/src/SFE/Compiler/ExtGadgetStatement.java
+++ b/compiler/frontend/src/SFE/Compiler/ExtGadgetStatement.java
@@ -1,0 +1,112 @@
+package SFE.Compiler;
+
+import java.io.PrintWriter;
+import java.util.List;
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.io.IOException;
+
+import SFE.Compiler.util.ExpressionIterator;
+import ccomp.CBuiltinFunctions;
+
+public class ExtGadgetStatement extends StatementWithOutputLine implements OutputWriter {
+    // each list in inVars corresponds to one of the structs in inLs
+    private final List<LvalExpression> inVars;
+    // each list in outVars corresponds to one of the structs in outStrP;
+    private final List<LvalExpression> outVars;
+    
+    private final int compNum;
+    private final int numIntermediateVar;
+    private int outputLine = -1;
+
+    // circuit writer for use by some ExpressionIterator.IterLLCalls
+    private PrintWriter circuit;
+
+    public ExtGadgetStatement(List<LvalExpression> inVars, List<LvalExpression> outVars, int compNum) {
+        this.inVars = inVars;
+        this.outVars = outVars;
+        this.compNum = compNum;
+        this.numIntermediateVar = queryIntermediateVars();
+    }
+
+    public Statement duplicate() {
+        return new ExtGadgetStatement(inVars, outVars, compNum);
+    }
+
+    public Statement toSLPTCircuit(Object obj) {
+         // resolve input and output variables to their corresponding field element
+         ExpressionIterator.iterL(inVars,ExpressionIterator.circuitIter());
+         ExpressionIterator.iterL(outVars,ExpressionIterator.circuitIter());
+         return this;
+    }
+   
+    public void toAssignmentStatements(StatementBuffer assignments) {
+        // change references
+        ExpressionIterator.iterL(inVars,ExpressionIterator.changeRefIter());
+        ExpressionIterator.iterL(outVars,ExpressionIterator.changeRefIter());
+
+        toAssignmentStatements_NoChangeRef(assignments);
+    }
+
+    public void toAssignmentStatements_NoChangeRef(StatementBuffer assignments) {
+        // make sure variables have references
+        ExpressionIterator.iterL(inVars,ExpressionIterator.addRefIter());
+        ExpressionIterator.iterL(outVars,ExpressionIterator.addRefIter());
+
+        outputLine = Program.getLineNumber();
+        assignments.add(this);
+    }
+
+    public int getOutputLine() {
+        return outputLine;  // returns -1 if not yet assigned
+    }
+
+    public void toCircuit(Object obj, PrintWriter circuit) {
+        this.circuit = circuit;
+
+        // ext_gadget
+        circuit.print(getOutputLine() + " " + CBuiltinFunctions.EXT_GADGET_NAME +
+                      " GADGETID " + Integer.toString(compNum) + " INPUTS [ ");
+
+        // input variables
+        ExpressionIterator.iterL(inVars,ExpressionIterator.toCircuitIter(circuit));
+        circuit.print("] OUTPUTS [ ");
+
+        // output variables
+        ExpressionIterator.iterL(outVars,ExpressionIterator.toCircuitIter(circuit));
+
+        // intermediate variables
+        circuit.print("] INTERMEDIATE ");
+        circuit.print(numIntermediateVar);
+
+        /*
+        for (int i = 0; i < numIntermediateVar; i++) {
+            circuit.print("G" + compNum + "V" + i + " ");
+        }
+        circuit.print(" ]");
+        */
+        circuit.println("\t// " + this.toString());
+    }
+
+    public String toString() {
+        return "ext_gadget #" + Integer.toString(compNum) +
+               " inVectors=" + inVars.size() +
+               " outVars=" + outVars.size() +
+               " intermediateVars=" + numIntermediateVar;
+    }
+
+    private int queryIntermediateVars() {
+        try {
+            Process p = Runtime.getRuntime().exec("../pepper/bin/gadget" + compNum + " size");
+            p.waitFor();
+            BufferedReader reader = new BufferedReader(new InputStreamReader(p.getInputStream()));
+            return Integer.parseInt(reader.readLine());   
+        } catch (IOException e) {
+            throw new RuntimeException(e + "\nDoes executable ./bin/gadget" + compNum + " exist?\n");
+        } catch (InterruptedException e) {
+            throw new RuntimeException("Interrupted while calling into gadget.");
+        } catch (NumberFormatException e) {
+            throw new RuntimeException("Invalid format. Does ./bin/gadget" + compNum + " return the number of intermediate variables of the gadget?");
+        }
+    }
+}

--- a/compiler/frontend/src/SFE/Compiler/ExtGadgetStatement.java
+++ b/compiler/frontend/src/SFE/Compiler/ExtGadgetStatement.java
@@ -17,16 +17,21 @@ public class ExtGadgetStatement extends StatementWithOutputLine implements Outpu
     
     private final int compNum;
     private final int numIntermediateVar;
+    private final long intermediateVarOffset;
     private int outputLine = -1;
 
     // circuit writer for use by some ExpressionIterator.IterLLCalls
     private PrintWriter circuit;
+
+    private static long GLOBAL_INTERMEDIATE_VAR_COUNT = 0;
 
     public ExtGadgetStatement(List<LvalExpression> inVars, List<LvalExpression> outVars, int compNum) {
         this.inVars = inVars;
         this.outVars = outVars;
         this.compNum = compNum;
         this.numIntermediateVar = queryIntermediateVars();
+        this.intermediateVarOffset = GLOBAL_INTERMEDIATE_VAR_COUNT;
+        GLOBAL_INTERMEDIATE_VAR_COUNT += this.numIntermediateVar;
     }
 
     public Statement duplicate() {
@@ -78,13 +83,9 @@ public class ExtGadgetStatement extends StatementWithOutputLine implements Outpu
         // intermediate variables
         circuit.print("] INTERMEDIATE ");
         circuit.print(numIntermediateVar);
+        circuit.print(" OFFSET ");
+        circuit.print(intermediateVarOffset);
 
-        /*
-        for (int i = 0; i < numIntermediateVar; i++) {
-            circuit.print("G" + compNum + "V" + i + " ");
-        }
-        circuit.print(" ]");
-        */
         circuit.println("\t// " + this.toString());
     }
 

--- a/compiler/frontend/src/SFE/Compiler/util/ExpressionIterator.java
+++ b/compiler/frontend/src/SFE/Compiler/util/ExpressionIterator.java
@@ -1,0 +1,90 @@
+package SFE.Compiler.util;
+
+import java.io.PrintWriter;
+import java.util.List;
+
+import SFE.Compiler.LvalExpression;
+import SFE.Compiler.Function;
+
+/**
+ * A collection of utility methods shared by multiple statements.
+ */
+public class ExpressionIterator {
+    // ** iterator infrastructure for input and output variables **
+    // iterate over the list of lists, doing... something.
+    public static void iterL(List<LvalExpression> thisL, IterLLCall illfn) {
+        for (int i=0; i<thisL.size(); i++) {
+            illfn.call(thisL,i);
+        }
+    }
+    public static void iterLL(List<List<LvalExpression>> lls, IterLLCall illfn, IterLLCall...repfns) {
+        int j=0;
+        for (List<LvalExpression> thisL : lls) {
+            // pre-walk call
+            if (repfns.length > 0) {
+                repfns[0].call(thisL,j++);
+            }
+
+            // per-element iter call
+            iterL(thisL,illfn);
+        }
+    }
+
+    // lack of lambdas brings us to this syntactic noise. Oh well.
+    public abstract class IterLLCall { abstract void call (List<LvalExpression> thisL, int i); }
+    protected final IterLLCall circuitIter = new IterLLCall() {
+        void call (List<LvalExpression> thisL, int i) { thisL.set(i,thisL.get(i).fieldEltAt(0)); }
+    };
+    protected final IterLLCall changeRefIter = new IterLLCall() {
+        void call (List<LvalExpression> thisL, int i) { thisL.set(i,thisL.get(i).changeReference(Function.getVars())); }
+    };
+    protected final IterLLCall addRefIter = new IterLLCall() {
+        void call (List<LvalExpression> thisL, int i) { thisL.get(i).addReference(); }
+    };
+    protected IterLLCall _toCircuitIter(final PrintWriter circuit) {
+        return new IterLLCall() {
+            void call (List<LvalExpression> thisL, int i) {
+                thisL.get(i).toCircuit(null, circuit);
+                circuit.print(" ");
+            }
+        };
+    }
+    protected IterLLCall _toCBrkIter(final PrintWriter circuit) {
+        return new IterLLCall() {
+            void call (List<LvalExpression> thisL, int j) {
+                // close the previous bracket unless we're on the first iteration
+                if (0 != j) {
+                    circuit.print("]");
+                }
+                circuit.print(" [ ");
+            }
+        };
+    }
+
+    private static final ExpressionIterator instance = new ExpressionIterator();
+
+    // get the field element in the toSLPTCircuit pass
+    public static IterLLCall circuitIter() {
+        return instance.circuitIter;
+    }
+
+    // change reference in the toAssignmentStatements pass
+    public static IterLLCall changeRefIter() {
+        return instance.changeRefIter;
+    }
+
+    // reference for each variable during the toAssignmentStatements pass
+    public static IterLLCall addRefIter() {
+        return instance.addRefIter;
+    }
+
+    // call toCircuit on each LvalExpression
+    public static IterLLCall toCircuitIter(PrintWriter circuit) {
+        return instance._toCircuitIter(circuit);
+    }
+
+    // bracketing utility
+    public static IterLLCall toCBrkIter(PrintWriter circuit) {
+        return instance._toCBrkIter(circuit);
+    }
+}

--- a/compiler/frontend/src/ccomp/CBuiltinFunctions.java
+++ b/compiler/frontend/src/ccomp/CBuiltinFunctions.java
@@ -12,5 +12,6 @@ public class CBuiltinFunctions {
                              COMMITMENTPUT_NAME = "commitmentput",
                              RAMPUT_ENHANCED_NAME = "ramput_fast",
                              RAMGET_ENHANCED_NAME = "ramget_fast",
-                             EXO_COMPUTE_NAME = "exo_compute";
+                             EXO_COMPUTE_NAME = "exo_compute",
+                             EXT_GADGET_NAME = "ext_gadget";
 }

--- a/compiler/frontend/src/ccomp/parser_hw/CCompiler.java
+++ b/compiler/frontend/src/ccomp/parser_hw/CCompiler.java
@@ -1080,37 +1080,37 @@ public class CCompiler {
 		return cc;
 	}
 
-    private void getOutputVars(LvalExpression outStrP, List<LvalExpression> outVars, Map<String, StructAccessOperator> saoMap, ArrayAccessOperator aao, StatementBuffer sb, String operation) {
-        if ( outStrP.getType() instanceof PointerType ) {
-            throw new RuntimeException(operation + " output data must be concrete types, not pointers.");
-        }
-        else if ( outStrP.getType() instanceof ArrayType ) {
-            // an array of things to add to the output variables list
-            final int outLen = ((ArrayType) outStrP.getType()).getLength();
-            for (int i=0; i<outLen; i++) {
-                // recursive call on each member of the array
-                getOutputVars(aao.resolve(outStrP,new IntConstant(i)), outVars, saoMap, aao, sb, operation);
-            }
-        } else if ( outStrP.getType() instanceof StructType ) {
-            // first, build the set of struct access operators we need for this struct
-            final StructType stT = (StructType) outStrP.getType();
-            final List<String> sFields = stT.getFields();
-            StructAccessOperator sao;
-            for (int i=0; i<sFields.size(); i++) {
-                // now recursively call on each element of the struct
-                // cache the StructAccessOperators so we don't have to create and destroy a billion of them
-                if ((sao = saoMap.get(sFields.get(i))) == null) {
-                    sao = new StructAccessOperator(sFields.get(i));
-                    saoMap.put(sFields.get(i),sao);
-                }
-                getOutputVars(sao.resolve(outStrP), outVars, saoMap, aao, sb, operation);
-            }
-        } else if ( outStrP.getType() instanceof SFE.Compiler.ScalarType ) {
-            addStatement(new InputStatement(outStrP), sb);
-            outVars.add(outStrP);
-        } else {
-            throw new RuntimeException(operation + " cannot interpret output variable of type " + outStrP.metaType.toString());
-        }
+	private void getOutputVars(LvalExpression outStrP, List<LvalExpression> outVars, Map<String, StructAccessOperator> saoMap, ArrayAccessOperator aao, StatementBuffer sb, String operation) {
+		if ( outStrP.getType() instanceof PointerType ) {
+			throw new RuntimeException(operation + " output data must be concrete types, not pointers.");
+		}
+		else if ( outStrP.getType() instanceof ArrayType ) {
+			// an array of things to add to the output variables list
+			final int outLen = ((ArrayType) outStrP.getType()).getLength();
+			for (int i=0; i<outLen; i++) {
+				// recursive call on each member of the array
+				getOutputVars(aao.resolve(outStrP,new IntConstant(i)), outVars, saoMap, aao, sb, operation);
+			}
+		} else if ( outStrP.getType() instanceof StructType ) {
+			// first, build the set of struct access operators we need for this struct
+			final StructType stT = (StructType) outStrP.getType();
+			final List<String> sFields = stT.getFields();
+			StructAccessOperator sao;
+			for (int i=0; i<sFields.size(); i++) {
+				// now recursively call on each element of the struct
+				// cache the StructAccessOperators so we don't have to create and destroy a billion of them
+				if ((sao = saoMap.get(sFields.get(i))) == null) {
+					sao = new StructAccessOperator(sFields.get(i));
+					saoMap.put(sFields.get(i),sao);
+				}
+				getOutputVars(sao.resolve(outStrP), outVars, saoMap, aao, sb, operation);
+			}
+		} else if ( outStrP.getType() instanceof SFE.Compiler.ScalarType ) {
+			addStatement(new InputStatement(outStrP), sb);
+			outVars.add(outStrP);
+		} else {
+			throw new RuntimeException(operation + " cannot interpret output variable of type " + outStrP.metaType.toString());
+		}
 	}
 	
 	private static int idFromExpression(SFE.Compiler.Expression expression) {
@@ -1125,179 +1125,179 @@ public class CCompiler {
 			String funcName, int parse_uid, StatementBuffer sb,
 			ArrayList<SFE.Compiler.Expression> args) {
 
-        if (funcName.equals(CBuiltinFunctions.EXO_COMPUTE_NAME)) {
-            // exo_compute(void *inputs[],uint32_t inSizes[], someStruct *output,int cmpNum);
-            // >> input arrays and output array must be ArrayType <<
+		if (funcName.equals(CBuiltinFunctions.EXO_COMPUTE_NAME)) {
+			// exo_compute(void *inputs[],uint32_t inSizes[], someStruct *output,int cmpNum);
+			// >> input arrays and output array must be ArrayType <<
 
-            // we do a lot of checking here.
-            // in principle this could be done in the constructor for the ExoComputeStatement,
-            // but it seems that in the case of the other builtin functions it's done here instead.
-            // We'll stick with that seeming convention.
-            if (args.size() != 4) {
-                throw new RuntimeException("Number of arguments to EXO_COMPUTE must be 4.");
-            }
-            // now let's have a look at these here inputs
-            final SFE.Compiler.Expression inLists = args.get(0);
-            final SFE.Compiler.Expression inLLens = args.get(1);
-            final SFE.Compiler.Expression outStrP = args.get(2);
-            final SFE.Compiler.Expression eCmpNum = args.get(3);
+			// we do a lot of checking here.
+			// in principle this could be done in the constructor for the ExoComputeStatement,
+			// but it seems that in the case of the other builtin functions it's done here instead.
+			// We'll stick with that seeming convention.
+			if (args.size() != 4) {
+				throw new RuntimeException("Number of arguments to EXO_COMPUTE must be 4.");
+			}
+			// now let's have a look at these here inputs
+			final SFE.Compiler.Expression inLists = args.get(0);
+			final SFE.Compiler.Expression inLLens = args.get(1);
+			final SFE.Compiler.Expression outStrP = args.get(2);
+			final SFE.Compiler.Expression eCmpNum = args.get(3);
 
-            if (!(inLists.metaType instanceof ArrayType)) {
-                throw new RuntimeException(
-                        "EXO_COMPUTE first arg must be a statically allocated array " + 
-                        "of pointers to lists of input for the exogenous computation.");
-            }
-            if (! (inLLens.metaType instanceof ArrayType)) {
-                throw new RuntimeException(
-                        "EXO_COMPUTE second arg must be a statically allocated array " + 
-                        "of lengths for the input lists.");
-            }
+			if (!(inLists.metaType instanceof ArrayType)) {
+				throw new RuntimeException(
+						"EXO_COMPUTE first arg must be a statically allocated array " + 
+						"of pointers to lists of input for the exogenous computation.");
+			}
+			if (! (inLLens.metaType instanceof ArrayType)) {
+				throw new RuntimeException(
+						"EXO_COMPUTE second arg must be a statically allocated array " + 
+						"of lengths for the input lists.");
+			}
 
-            final ArrayType atInL = (ArrayType) inLists.metaType;
-            final ArrayType atLnL = (ArrayType) inLLens.metaType;
-            if (atLnL.getLength() != atInL.getLength()) {
-                throw new RuntimeException(
-                        "EXO_COMPUTE first and second args must be arrays of the same " +
-                        "length! First are arg lists, second are lengths of arg lists.");
-            }
+			final ArrayType atInL = (ArrayType) inLists.metaType;
+			final ArrayType atLnL = (ArrayType) inLLens.metaType;
+			if (atLnL.getLength() != atInL.getLength()) {
+				throw new RuntimeException(
+						"EXO_COMPUTE first and second args must be arrays of the same " +
+						"length! First are arg lists, second are lengths of arg lists.");
+			}
 
-            // check the first arguments and save off their contents for creating the ExoComputeStatement instance
-            final List<List<LvalExpression>> inVars = new ArrayList<List<LvalExpression>>(atInL.getLength());
-            final ArrayAccessOperator aao = new ArrayAccessOperator();
-            for (int i=0;i<atInL.getLength();i++) {
-                final IntConstant idx = new IntConstant(i);
+			// check the first arguments and save off their contents for creating the ExoComputeStatement instance
+			final List<List<LvalExpression>> inVars = new ArrayList<List<LvalExpression>>(atInL.getLength());
+			final ArrayAccessOperator aao = new ArrayAccessOperator();
+			for (int i=0;i<atInL.getLength();i++) {
+				final IntConstant idx = new IntConstant(i);
 
-                // get the ith LvalExpression in the 1st arg, which should be a pointer
-                final LvalExpression lPtr = aao.resolve((LvalExpression) inLists,idx);
-                if (!(lPtr.getType() instanceof PointerType)) {
-                    throw new RuntimeException(
-                            "EXO_COMPUTE first arg must be an array of pointers to input lists.");
-                }
+				// get the ith LvalExpression in the 1st arg, which should be a pointer
+				final LvalExpression lPtr = aao.resolve((LvalExpression) inLists,idx);
+				if (!(lPtr.getType() instanceof PointerType)) {
+					throw new RuntimeException(
+							"EXO_COMPUTE first arg must be an array of pointers to input lists.");
+				}
 
-                // input list length for the ith input list
-                final FloatConstant aFlt = FloatConstant.toFloatConstant(
-                        aao.resolve((LvalExpression) inLLens,idx));
-                final BigInteger aNum = aFlt.getNumerator();
-                final BigInteger aDen = aFlt.getDenominator();
-                final int tmpLen = aNum.divide(aDen).intValue();
+				// input list length for the ith input list
+				final FloatConstant aFlt = FloatConstant.toFloatConstant(
+						aao.resolve((LvalExpression) inLLens,idx));
+				final BigInteger aNum = aFlt.getNumerator();
+				final BigInteger aDen = aFlt.getDenominator();
+				final int tmpLen = aNum.divide(aDen).intValue();
 
-                final List<LvalExpression> tmpList = new ArrayList<LvalExpression>(tmpLen);
-                inVars.add(tmpList);
+				final List<LvalExpression> tmpList = new ArrayList<LvalExpression>(tmpLen);
+				inVars.add(tmpList);
 
-                final PointerAccessOperator pao = new PointerAccessOperator();
-                // iterate over length of list, resolving and adding to input list
-                for (int j=0;j<tmpLen;j++) {
-                    final LvalExpression pVal = pao.resolve(
-                                new SFE.Compiler.BinaryOpExpression(new PlusOperator(),lPtr,IntConstant.valueOf(j)));
-                    //System.out.println(pVal.getName().toString());
-                    tmpList.add(pVal);
-                }
-            }
-            
-            // check third argument type: static array of structs
-            if (outStrP.metaType instanceof PointerType) {
-                throw new RuntimeException(
-                        "EXO_COMPUTE third arg must be statically allocated storage " +
-                        "for holding data from the exogenous compuation.");
-            }
-            final List<LvalExpression> outVars = new ArrayList<LvalExpression>();
-            final Map<String, StructAccessOperator> saoMap = new HashMap<String, StructAccessOperator>();
+				final PointerAccessOperator pao = new PointerAccessOperator();
+				// iterate over length of list, resolving and adding to input list
+				for (int j=0;j<tmpLen;j++) {
+					final LvalExpression pVal = pao.resolve(
+								new SFE.Compiler.BinaryOpExpression(new PlusOperator(),lPtr,IntConstant.valueOf(j)));
+					//System.out.println(pVal.getName().toString());
+					tmpList.add(pVal);
+				}
+			}
+			
+			// check third argument type: static array of structs
+			if (outStrP.metaType instanceof PointerType) {
+				throw new RuntimeException(
+						"EXO_COMPUTE third arg must be statically allocated storage " +
+						"for holding data from the exogenous compuation.");
+			}
+			final List<LvalExpression> outVars = new ArrayList<LvalExpression>();
+			final Map<String, StructAccessOperator> saoMap = new HashMap<String, StructAccessOperator>();
 
-            // get the output variables, recursively expanding the structure of each element
-            getOutputVars((LvalExpression) SFE.Compiler.Expression.fullyResolve(outStrP), outVars, saoMap, aao, sb, funcName);
+			// get the output variables, recursively expanding the structure of each element
+			getOutputVars((LvalExpression) SFE.Compiler.Expression.fullyResolve(outStrP), outVars, saoMap, aao, sb, funcName);
 
-            // get the exoId so that we can set the scope name appropriately
-            // exogenous computation number, that is, the identifier for the
-            // backend which code to run on this input (we provide executables
-            // named exo0, exo1, etc.)
-            final int exoId = idFromExpression(eCmpNum);
+			// get the exoId so that we can set the scope name appropriately
+			// exogenous computation number, that is, the identifier for the
+			// backend which code to run on this input (we provide executables
+			// named exo0, exo1, etc.)
+			final int exoId = idFromExpression(eCmpNum);
 
-            /* begin test code
-            // print some information about the arguments
-            System.out.print(Integer.toString(atInL.getLength()) + " " + atInL.getComponentType() + " ");
-            System.out.println(((LvalExpression)inLists).fieldEltAt(0));
-            System.out.print(SFE.Compiler.Expression.fullyResolve(inLLens).getClass().getName().toString() + " ");
-            System.out.println(inLLens.metaType.toString());
-            System.out.print(SFE.Compiler.Expression.fullyResolve(outStrP).getClass().getName().toString() + " ");
-            System.out.println(outStrP.getType().toString());
-            // end test code */
+			/* begin test code
+			// print some information about the arguments
+			System.out.print(Integer.toString(atInL.getLength()) + " " + atInL.getComponentType() + " ");
+			System.out.println(((LvalExpression)inLists).fieldEltAt(0));
+			System.out.print(SFE.Compiler.Expression.fullyResolve(inLLens).getClass().getName().toString() + " ");
+			System.out.println(inLLens.metaType.toString());
+			System.out.print(SFE.Compiler.Expression.fullyResolve(outStrP).getClass().getName().toString() + " ");
+			System.out.println(outStrP.getType().toString());
+			// end test code */
 
-            // don't do this: we only need to create variables for the outputs, and we've done that already above
-            /* create output variables
-            final ArrayType atOut = (ArrayType) outStrP.metaType;
-            final LvalExpression inListsVar = scope.addVar("exo:inLists",new ArrayType(atInL.getComponentType(),atInL.getLength()),false);
-            final LvalExpression inLLensVar = scope.addVar("exo:inLLens",new ArrayType(atLnL.getComponentType(),atLnL.getLength()),false);
-            final LvalExpression outStrPVar = scope.addVar("exo:outStrP",new ArrayType(atOut.getComponentType(),atOut.getLength()),false);
-            final LvalExpression eCmpNumVar = scope.addVar("exo:eCmpNum",new IntType(),false);
-            addStatement(asId(inListsVar,inLists),sb);
-            addStatement(asId(inLLensVar,inLLens),sb);
-            addStatement(asId(outStrPVar,outStrP),sb);
-            addStatement(asId(eCmpNumVar,IntConstant.valueOf(exoId)),sb);
-            // end assign input variables */
+			// don't do this: we only need to create variables for the outputs, and we've done that already above
+			/* create output variables
+			final ArrayType atOut = (ArrayType) outStrP.metaType;
+			final LvalExpression inListsVar = scope.addVar("exo:inLists",new ArrayType(atInL.getComponentType(),atInL.getLength()),false);
+			final LvalExpression inLLensVar = scope.addVar("exo:inLLens",new ArrayType(atLnL.getComponentType(),atLnL.getLength()),false);
+			final LvalExpression outStrPVar = scope.addVar("exo:outStrP",new ArrayType(atOut.getComponentType(),atOut.getLength()),false);
+			final LvalExpression eCmpNumVar = scope.addVar("exo:eCmpNum",new IntType(),false);
+			addStatement(asId(inListsVar,inLists),sb);
+			addStatement(asId(inLLensVar,inLLens),sb);
+			addStatement(asId(outStrPVar,outStrP),sb);
+			addStatement(asId(eCmpNumVar,IntConstant.valueOf(exoId)),sb);
+			// end assign input variables */
 
-            // now we have everything we need to create the ExoComputeStatement
-            addStatement(new ExoComputeStatement(inVars,outVars,exoId), sb);
+			// now we have everything we need to create the ExoComputeStatement
+			addStatement(new ExoComputeStatement(inVars,outVars,exoId), sb);
 
-            return VoidRetVal;
+			return VoidRetVal;
 		}
 		
 		if (funcName.equals(CBuiltinFunctions.EXT_GADGET_NAME)) {
 			// ext_gadget(void *inputs, someStruct *output,int cmpNum);
 			// >> input arrays and output array must be ArrayType <<
 			if (args.size() != 3) {
-                throw new RuntimeException("Number of arguments to EXT_GADGET must be 3.");
-            }
-            // now let's have a look at these here inputs
-            final SFE.Compiler.Expression inList = args.get(0);
-            final SFE.Compiler.Expression outStrP = args.get(1);
-            final SFE.Compiler.Expression eCmpNum = args.get(2);
+				throw new RuntimeException("Number of arguments to EXT_GADGET must be 3.");
+			}
+			// now let's have a look at these here inputs
+			final SFE.Compiler.Expression inList = args.get(0);
+			final SFE.Compiler.Expression outStrP = args.get(1);
+			final SFE.Compiler.Expression eCmpNum = args.get(2);
 
-            // check first argument type: static array of structs
-            if (!(inList.metaType instanceof ArrayType)) {
-                throw new RuntimeException(
-                        "EXT_GADGET first arg must be a statically allocated array " + 
-                        "of pointers to lists of input for the exogenous computation.");
+			// check first argument type: static array of structs
+			if (!(inList.metaType instanceof ArrayType)) {
+				throw new RuntimeException(
+						"EXT_GADGET first arg must be a statically allocated array " + 
+						"of pointers to lists of input for the exogenous computation.");
 			}
 			final ArrayType atInL = (ArrayType) inList.metaType;
 			final List<LvalExpression> inVars = new ArrayList<LvalExpression>(atInL.getLength());
 			final ArrayAccessOperator aao = new ArrayAccessOperator();
 			final PointerAccessOperator pao = new PointerAccessOperator();
 			for (int i=0;i<atInL.getLength();i++) {
-                final IntConstant idx = new IntConstant(i);
+				final IntConstant idx = new IntConstant(i);
 
 				// get the ith LvalExpression in the 1st arg and add it to inputs
 				
-                // iterate over length of list, resolving and adding to input list
-                final LvalExpression lVal = pao.resolve(
-                    new SFE.Compiler.BinaryOpExpression(new PlusOperator(), inList, IntConstant.valueOf(i)));
-                if (!(lVal.getType() instanceof SFE.Compiler.ScalarType)) {
+				// iterate over length of list, resolving and adding to input list
+				final LvalExpression lVal = pao.resolve(
+					new SFE.Compiler.BinaryOpExpression(new PlusOperator(), inList, IntConstant.valueOf(i)));
+				if (!(lVal.getType() instanceof SFE.Compiler.ScalarType)) {
 					throw new RuntimeException(
 						"EXT_GADGET first arg must be an array of scalars.");
 				}
 				inVars.add(lVal);
 			}
-			            
-            // check second argument type: static array of structs
-            if (outStrP.metaType instanceof PointerType) {
-                throw new RuntimeException(
-                        "EXT_GADGET second arg must be statically allocated storage " +
-                        "for holding data from the exogenous compuation.");
-            }
-            final List<LvalExpression> outVars = new ArrayList<LvalExpression>();
+						
+			// check second argument type: static array of structs
+			if (outStrP.metaType instanceof PointerType) {
+				throw new RuntimeException(
+						"EXT_GADGET second arg must be statically allocated storage " +
+						"for holding data from the exogenous compuation.");
+			}
+			final List<LvalExpression> outVars = new ArrayList<LvalExpression>();
 			final Map<String, StructAccessOperator> saoMap = new HashMap<String, StructAccessOperator>();
 
-            // get the output variables, recursively expanding the structure of each element
-            getOutputVars((LvalExpression) SFE.Compiler.Expression.fullyResolve(outStrP), outVars, saoMap, aao, sb, funcName);
+			// get the output variables, recursively expanding the structure of each element
+			getOutputVars((LvalExpression) SFE.Compiler.Expression.fullyResolve(outStrP), outVars, saoMap, aao, sb, funcName);
 
-            // get the gadgetId so that we can set the scope name appropriately
+			// get the gadgetId so that we can set the scope name appropriately
 			// gadget number, that is, the identifier for the backend which code 
 			// to run on this input (we provide executables  named gadget0, gadget1, etc.)
-            int gadgetId = idFromExpression(eCmpNum);
+			int gadgetId = idFromExpression(eCmpNum);
 
-            // now we have everything we need to create the ExtGadgetStatement
-            addStatement(new ExtGadgetStatement(inVars,outVars,gadgetId), sb);
+			// now we have everything we need to create the ExtGadgetStatement
+			addStatement(new ExtGadgetStatement(inVars,outVars,gadgetId), sb);
 
-            return VoidRetVal;
+			return VoidRetVal;
 		}
 
 		// fast_ram implementation.
@@ -1882,13 +1882,13 @@ public class CCompiler {
 			// strValue is wrapped in quotes
 			strValue = strValue.substring(1, strValue.length() - 1);
 
-                        if (strValue.contains("\\")){
-                                System.out.println(
-                                        "WARNING: Backslash in string literal"
-                                        + " not treated as escape character but as"
-                                        + " real backslash: " + strValue
-                                );
-                        }
+						if (strValue.contains("\\")){
+								System.out.println(
+										"WARNING: Backslash in string literal"
+										+ " not treated as escape character but as"
+										+ " real backslash: " + strValue
+								);
+						}
 
 			int N = strValue.length() + 1; // +1 for C null-terminated string
 			LvalExpression[] list = new LvalExpression[N];
@@ -1973,27 +1973,27 @@ public class CCompiler {
 			return toRet;
 		} else if (e.constType.equals("char")) {
 			// strValue is wrapped in single quotes
-                        if (val.length() != 3){
+						if (val.length() != 3){
 				throw new RuntimeException("Char constants must"
-                                + " be a single character long, escape sequences"
-                                + " not supported: "
+								+ " be a single character long, escape sequences"
+								+ " not supported: "
 				+ val);
-                        }
+						}
 
-                        Integer charValue = (int) val.charAt(1);
+						Integer charValue = (int) val.charAt(1);
 
-                        IntConstant toRet = IntConstant.valueOf(charValue);
+						IntConstant toRet = IntConstant.valueOf(charValue);
 
 			Type charType = typetable.get("char");
 
-                        if (TypeHeirarchy.isSubType(toRet.getType(), charType)){
-                                toRet.metaType = charType;
-                        } else {
-                                throw new RuntimeException(
-                                "Assertion error: "
-                                + "Char constant too large?" + val
-                                );
-                        }
+						if (TypeHeirarchy.isSubType(toRet.getType(), charType)){
+								toRet.metaType = charType;
+						} else {
+								throw new RuntimeException(
+								"Assertion error: "
+								+ "Char constant too large?" + val
+								);
+						}
 
 			return toRet;
 		} else {
@@ -2142,25 +2142,25 @@ public class CCompiler {
 	 */
 	private int toInt(Expression k) {
 		if (k instanceof Constant) {
-            final String constStr = ((Constant) k).value.toString();
-            if (constStr.length() >= 2) {
-                switch (constStr.substring(0,2)) {
-                    case "0b":
-                    case "0B":
-                        return Integer.parseInt(constStr.substring(2),2);
-                    case "0x":
-                    case "0X":
-                        return Integer.parseInt(constStr.substring(2),16);
-                    default:
-                        if (constStr.substring(0,1).equals("0")) {
-                            return Integer.parseInt(constStr.substring(1),8);
-                        } else {
-                            return Integer.parseInt(constStr);
-                        }
-                }
-            } else {
-                return Integer.parseInt(constStr);
-            }
+			final String constStr = ((Constant) k).value.toString();
+			if (constStr.length() >= 2) {
+				switch (constStr.substring(0,2)) {
+					case "0b":
+					case "0B":
+						return Integer.parseInt(constStr.substring(2),2);
+					case "0x":
+					case "0X":
+						return Integer.parseInt(constStr.substring(2),16);
+					default:
+						if (constStr.substring(0,1).equals("0")) {
+							return Integer.parseInt(constStr.substring(1),8);
+						} else {
+							return Integer.parseInt(constStr);
+						}
+				}
+			} else {
+				return Integer.parseInt(constStr);
+			}
 		} else if (k instanceof MultiExpression) {
 			MultiExpression m = (MultiExpression) k;
 			if (m.size() == 1) {

--- a/ext_gadget.txt
+++ b/ext_gadget.txt
@@ -1,0 +1,54 @@
+This file provides some information on using ext_gadget() in
+verifiable computations to inject arbitrary external constraint subsystems
+that have can be compiled and verified outside of pepper.
+
+You call ext_gadget like any other C function, but the compiler
+treats it in a special way. When the prover is executing the
+computation and solving the constraints, it will execute a
+user-provided program as a child process. This program needs to respond to
+three commands.
+
+1. <exe> size: 	returns the number of intermediate variables the external subsystem 
+				requires (used to allocate space in the pepper generated system)
+2. <exe> constraints: returns the constraints as a list of the form:
+					  [
+						{indexA1: coeffA1, indexA2: coeffA2, ...}, 
+						{indexB1: coeffB1, indexB2: coeffB2, ...}, 
+						{indexC1: coeffC1, indexC2: coeffC2, ...}
+					  ] 
+3. <exe> witness [inputs]: Generate a fulfilling assignment for the constraints in the 
+						   gadget and return it separated by a space (including inputs)
+
+An example of ext_gadget in action can be found here:
+    https://github.com/https://github.com/pepper-project/pequin/tree/master/pepper/apps/ext_gadget_example.c
+
+The prototype for ext_gadget, were it actually a C function, would look
+something like this:
+    void ext_gadget(field_t *inputs, field_t *output, int gadget_number);
+(where field_t represents a field element).
+
+Some information about the arguments to ext_gadget:
+
+  - inputs is an array of input variables provided to the gadget.
+
+  - output is an array whose contents are set by the gadget when it
+    computes the witness.
+
+  - gadget_number tells the prover what executable to run. The number
+    is appended to the string "gadget" (e.g., "gadget0"), and the prover
+    will expect to find an executable of this name in the pepper/bin
+    directory.
+
+Each input value is provided as a large integer strings. 
+Outputs from the program should be in a format that's
+compatible with the libgmp function mpq_set_str().
+
+We have an implementation of ext gadgets:
+  https://github.com/pepper-project/pequin/tree/master/pepper/ext_gadget_bridge.cpp
+
+If you want to see in more detail how the prover constructs the inputs
+and interprets the outputs, here's the code in the prover that actually
+handles ext_gadget calls:
+    https://github.com/pepper-project/pepper/blob/master/compiler/frontend/src/SFE/Compiler/ExtGadgetStatement.java#L98-L112
+	https://github.com/pepper-project/pepper/blob/master/compiler/backend/zcc_parser.py#L1674-L1712
+	https://github.com/pepper-project/pepper/blob/master/pepper/libv/computation_p.cpp#L709

--- a/pepper/Makefile
+++ b/pepper/Makefile
@@ -95,8 +95,7 @@ pepper_verifier_%: pepper_verifier.cpp objs common_defs.h $(BINDIR)/%.params
 pepper_prover_%: pepper_prover.cpp objs common_defs.h $(BINDIR)/%.params
 	$(eval TARG := $(@:pepper_prover_%=%))
 	$(CXX) $(CXXFLAGS) -DNAME=\"$(TARG)\" $(IFLAGS)  $<  -o $(BINDIR)/$@ $(COMMON_LIB_OBJFILES) $(LDFLAGS)
-
-
+	
 objs: $(COMMON_LIB_OBJFILES)
 		@echo + compiling common objs
 
@@ -178,3 +177,6 @@ clean:
 	rm -f ../compiler/tmptime
 	cd ../compiler/frontend; make clean; 
 	cd ../compiler/buffetfsm; make clean;
+
+gadget%: ext_gadget_bridge.cpp
+	$(CXX) $(CXXFLAGS) -UBINARY_OUTPUT -DNAME=\"$(TARG)\" $(IFLAGS)  $<  -o $(BINDIR)/$@ $(COMMON_LIB_OBJFILES) $(LDFLAGS)

--- a/pepper/Makefile
+++ b/pepper/Makefile
@@ -92,7 +92,6 @@ pepper_verifier_%: pepper_verifier.cpp objs common_defs.h $(BINDIR)/%.params
 	@echo ""
 	$(CXX) $(CXXFLAGS) -DNAME=\"$(TARG)\" $(IFLAGS)  $<  -o $(BINDIR)/$@ $(COMMON_LIB_OBJFILES) $(LDFLAGS)
 
-
 pepper_prover_%: pepper_prover.cpp objs common_defs.h $(BINDIR)/%.params
 	$(eval TARG := $(@:pepper_prover_%=%))
 	$(CXX) $(CXXFLAGS) -DNAME=\"$(TARG)\" $(IFLAGS)  $<  -o $(BINDIR)/$@ $(COMMON_LIB_OBJFILES) $(LDFLAGS)

--- a/pepper/apps/ext_gadget_example.c
+++ b/pepper/apps/ext_gadget_example.c
@@ -1,0 +1,18 @@
+#include <stdint.h>
+ #define INPUT_SIZE 512
+#define OUTPUT_SIZE 256
+ struct In { uint32_t preimage[INPUT_SIZE]; };
+ struct Out { uint32_t value[OUTPUT_SIZE]; };
+ struct Hash { 
+    uint32_t values[OUTPUT_SIZE];
+};
+ void compute(struct In *input, struct Out *output){
+    uint32_t *gadget_inputs[1] = {input->preimage};
+    uint32_t lens[1] = {INPUT_SIZE};
+    struct Hash hash[1];
+    ext_gadget(input->preimage,hash,0);
+    int i;
+    for (i = 0; i < OUTPUT_SIZE; i++) {
+        output->value[i] = hash->values[i];
+    }
+}

--- a/pepper/ext_gadget_bridge.cpp
+++ b/pepper/ext_gadget_bridge.cpp
@@ -1,0 +1,139 @@
+/**
+ * This is an example bridge to include external gadgets into pepper programs.
+ * In this example, we are using a libsnark protoboard for SHA256, which compiles
+ * in ~27k constraints vs >70k constraints if implemented natively in pepper.
+ * 
+ * To replace with your own gadget, simply provide a different protoboard in the 
+ * `_getProtoboard` method. And adjust the input/output sizes accordingly.
+ * 
+ * In general, bridges have to be executables that respond to three arguments:
+ * 1. gadgetN size: returns the number of intermediate variables the gadget requires
+ * 2. gadgetN constraints: returns the constraints as a list of the form:
+ *   [{indexA1: coeffA1, indexAs2: coeffA2, ...}, {indexB1: coeffB1, indexC2: coeffB2, ...}, {indexC1: coeffC1, indexC2: coeffC2, ...}] 
+ * 3. gadgetN witness [input1, input2 ...]: Generate a fulfilling assignment for the constraints in the gadget and return it separated by a space (including inputs)
+ */
+
+#include <iostream>
+
+#include "libsnark/gadgetlib1/gadget.hpp"
+#include "libff/common/default_types/ec_pp.hpp"
+
+#include <libsnark/common/default_types/r1cs_ppzksnark_pp.hpp>
+#include <libsnark/gadgetlib1/gadgets/hashes/sha256/sha256_gadget.hpp>
+#include <libsnark/zk_proof_systems/ppzksnark/r1cs_ppzksnark/r1cs_ppzksnark.hpp>
+
+using namespace libsnark;
+using namespace libff;
+
+typedef libff::Fr<libsnark::default_r1cs_ppzksnark_pp> FieldT;
+
+#define BUFLEN 10240
+#define LEFT_INPUT_SIZE 256
+#define RIGHT_INPUT_SIZE 256
+#define OUTPUT_SIZE 256
+
+void constraint_to_json(linear_combination<FieldT> constraints, std::stringstream &ss)
+{
+    ss << "{";
+    uint count = 0;
+    for (const linear_term<FieldT>& lt : constraints.terms)
+    {
+		if (lt.coeff == 0) {
+            continue;
+        } 
+        if (count != 0) {
+            ss << ",";
+        }
+        
+        ss << '"' << lt.index << '"' << ":" << '"' << lt.coeff.as_bigint() << '"';
+        count++;
+    }
+    ss << "}";
+}
+
+std::string r1cs_to_json(protoboard<FieldT> pb)
+{
+    r1cs_constraint_system<FieldT> constraints = pb.get_constraint_system();
+    std::stringstream ss;
+    for (size_t c = 0; c < constraints.num_constraints(); ++c)
+    {
+        ss << "[";// << "\"A\"=";
+        constraint_to_json(constraints.constraints[c].a, ss);
+        ss << ",";// << "\"B\"=";
+        constraint_to_json(constraints.constraints[c].b, ss);
+        ss << ",";// << "\"C\"=";;
+        constraint_to_json(constraints.constraints[c].c, ss);
+    	ss << "]\n";
+    }
+    ss.rdbuf()->pubseekpos(0, std::ios_base::out);
+    return ss.str();
+}
+
+std::string witness_to_json(protoboard<FieldT> pb) {
+	r1cs_auxiliary_input<FieldT> values = pb.full_variable_assignment();
+	std::stringstream ss;
+	for (size_t i = 0; i < values.size(); ++i) {
+		ss << values[i].as_bigint() << " ";
+	}
+	return ss.str();
+}
+
+protoboard<FieldT> _getProtoboard(const char* assignment)
+{
+    libsnark::default_r1cs_ppzksnark_pp::init_public_params();
+    protoboard<FieldT> pb;
+
+    digest_variable<FieldT> left(pb, LEFT_INPUT_SIZE, "left");
+    digest_variable<FieldT> right(pb, RIGHT_INPUT_SIZE, "right");
+    digest_variable<FieldT> output(pb, OUTPUT_SIZE, "output");
+
+    sha256_two_to_one_hash_gadget<FieldT> f(pb, left, right, output, "f");
+    f.generate_r1cs_constraints();
+
+	if (assignment) {
+		libff::bit_vector left_bv;
+    	libff::bit_vector right_bv;
+     	for (int i = 0; i < LEFT_INPUT_SIZE; i++) {
+        	left_bv.push_back(assignment[2*i] - '0');
+    	}
+    	for (int i = LEFT_INPUT_SIZE; i < LEFT_INPUT_SIZE + RIGHT_INPUT_SIZE; i++) {
+        	right_bv.push_back(assignment[2*i] - '0');
+    	}
+     	left.generate_r1cs_witness(left_bv);
+    	right.generate_r1cs_witness(right_bv);
+     	f.generate_r1cs_witness();
+    
+    	assert(pb.is_satisfied());
+	}
+    
+    return pb;
+}
+
+void validate(std::string json) {
+
+}
+
+int main(int argc, char **argv) 
+{ 
+	if (argc != 2) {
+		std::cout << "Needs to be called with a command.\n";
+		return 1;
+	}
+
+	if (strcmp("size", argv[1]) == 0) {
+		protoboard<FieldT> pb = _getProtoboard(nullptr);
+		std::cout << (pb.num_variables() - LEFT_INPUT_SIZE - RIGHT_INPUT_SIZE - OUTPUT_SIZE) << "\n";
+	} else if (strcmp("constraints", argv[1]) == 0) {
+		protoboard<FieldT> pb = _getProtoboard(nullptr);
+		std::cout << r1cs_to_json(pb);
+	} else if (strcmp("witness", argv[1]) == 0) {
+		std::string input_line;
+		std::getline(std::cin, input_line);
+		protoboard<FieldT> pb = _getProtoboard(input_line.c_str());
+		std::cout << witness_to_json(pb);
+	} else {
+		std::cout << "Unknown command `" << argv[1] << "`! Expecting size, constraints or witness.\n";
+		return 1;
+	}
+    return 0; 
+} 

--- a/pepper/libv/computation_p.h
+++ b/pepper/libv/computation_p.h
@@ -55,8 +55,9 @@ protected:
     void compute_db_get_sibling_hash(FILE* pws_file);
 
     void compute_exo_compute(FILE *pws_file);
-    void compute_exo_compute_getLL(std::vector< std::vector<std::string> > &inLL, FILE *pws_file, char *buf);
-    void compute_exo_compute_getL (std::vector<std::string> &inL, FILE *pws_file, char *buf);
+    void compute_ext_gadget(FILE *pws_file);
+    void getLL(std::vector< std::vector<std::string> > &inLL, FILE *pws_file, char *buf);
+    void getL (std::vector<std::string> &inL, FILE *pws_file, char *buf);
 
     void compute_fast_ramget(FILE* pws_file);
     void compute_fast_ramput(FILE* pws_file);

--- a/pepper/pepper_verifier.cpp
+++ b/pepper/pepper_verifier.cpp
@@ -81,7 +81,7 @@ void run_setup(int num_constraints, int num_inputs,
             libsnark::linear_combination<FieldT> A, B, C;
             
             while(Aj == currentconstraint && Amat)
-                {                  
+                {        
                     if (Ai <= num_intermediate_vars && Ai != 0)
                         Ai += num_inputs_outputs;
                     else if (Ai > num_intermediate_vars)


### PR DESCRIPTION
This pull request will allow people to call into external gadgets (e.g. libsnark's `sha256_two_to_one_hash_gadget`) by providing an executable that can respond to three commands

1. `gadgetN size`: returns the number of intermediate variables the gadget requires
2. `gadgetN constraints a|b|c`: returns the constraints for the a|b|c matrix in the form `row column value`
3. `gadgetN witness [inputs]`: given the inputs, generate a fulfilling assignment for the constraints in the gadget and return it as a list of values.

This will allow you to use highly optimized gadget for expensive operations (e.g. hashing) while still using the convenience pepper offers for iterations, conditionals and other high level processing code. An example .c file using the ext_gadget call can be seen here: https://pastebin.com/kMExVe3L

The pull request will contain out of three steps:

1.  Add support for an ext_gadget function call in the frontend (similar to exo_compute)
2. In the backend, when reading the ext_gadget command insert the external R1CS into the R1CS we are currently building.
3. In the prover, when trying to process the ext_gadget command call into the gadget to get the witness instead of letting the prover run

I am planning to break this PR up into multiple commits to make it easier to review. Please feel free to comment with suggestions already now.
I'm more than happy to redesign or iterate on the approach if you think there is a better one.