### PR TITLE
Fix compute_printf

### DIFF
--- a/pepper/libv/computation_p.cpp
+++ b/pepper/libv/computation_p.cpp
@@ -944,7 +944,7 @@ void ComputationProver::compute_printf(FILE* pws_file) {
   std::string format;
   while(true){
     next_token_or_error(pws_file, cmds);
-    if (strcmp(cmds, "NUM_X")) {
+    if (strcmp(cmds, "NUM_X") == 0) {
       break;
     }
     format += cmds;
@@ -970,6 +970,7 @@ void ComputationProver::compute_printf(FILE* pws_file) {
   gmp_printf("PRINTF in computation_p %d:\n", num_args);
   gmp_printf(format.c_str(), args[0], args[1], args[2], args[3],
   args[4], args[5], args[6], args[7], args[8], args[9]);
+  gmp_printf("\n");
 }
 
 void ComputationProver::compute_genericget(FILE* pws_file) {


### PR DESCRIPTION
Currently, printf statements are not working. Running the prove for the following program:

```C
#include <stdint.h>

struct In { int in; };
struct Out { int out; };

void compute(struct In *input, struct Out *output){
    printf("%d", input->in);
    output->out = input->in;
}
```

Outputs the following error instead of actually printing the input:

```
Format error in printf, Expected : X Actual: 1
PRINTF in computation_p 0:
Unrecognized token: X
Unrecognized token: I0
```

Reason for that is that we are looking for the token `NUM_X` in `ComputationProver::compute_printf` by checking if `strcmp` is true-ish. `strcmp` returns 0 if the strings are equal, thus we have to check for a false-ish value. 

After this change proving the program above returns:
```
PRINTF in computation_p 1:
"1"
```