### PR TITLE
Pass arguments to input generation function

### DIFF
--- a/compiler/backend/templates/verifier_inp_gen.cc.tmpl
+++ b/compiler/backend/templates/verifier_inp_gen.cc.tmpl
@@ -13,7 +13,7 @@ ${computation_classname}VerifierInpGen::${computation_classname}VerifierInpGen()
 
 //Refer to ${output_prefix}_cons.h for constants to use when generating input.
 void ${computation_classname}VerifierInpGen::create_input(mpq_t* input_q, int
-num_inputs) {
+num_inputs, char *argv[]) {
 \#if IS_REDUCER == 0
 ${create_input}
 \#endif

--- a/compiler/backend/templates/verifier_inp_gen.h.tmpl
+++ b/compiler/backend/templates/verifier_inp_gen.h.tmpl
@@ -12,7 +12,7 @@ class ${computation_classname}VerifierInpGen : public InputCreator {
   public:
     ${computation_classname}VerifierInpGen();
 
-    virtual void create_input(mpq_t* input_q, int num_inputs);
+    virtual void create_input(mpq_t* input_q, int num_inputs, char *argv[]);
 
     Venezia* v;
 };

--- a/compiler/backend/templates/verifier_inp_gen_hw.cc.tmpl
+++ b/compiler/backend/templates/verifier_inp_gen_hw.cc.tmpl
@@ -12,11 +12,11 @@ ${computation_classname}VerifierInpGenHw::${computation_classname}VerifierInpGen
 }
 
 //Refer to ${output_prefix}_cons.h for constants to use when generating input.
-void ${computation_classname}VerifierInpGenHw::create_input(mpq_t* input_q, int num_inputs)
+void ${computation_classname}VerifierInpGenHw::create_input(mpq_t* input_q, int num_inputs, char *argv[])
 {
   \#if IS_REDUCER == 0
   //Default implementation is provided by compiler
-  compiler_implementation.create_input(input_q, num_inputs);
+  compiler_implementation.create_input(input_q, num_inputs, char *argv[]);
   \#endif
 
   // states that should be persisted and may not be generated everytime should be created here.

--- a/compiler/backend/templates/verifier_inp_gen_hw.h.tmpl
+++ b/compiler/backend/templates/verifier_inp_gen_hw.h.tmpl
@@ -17,7 +17,7 @@ class ${computation_classname}VerifierInpGenHw : public InputCreator {
   public:
     ${computation_classname}VerifierInpGenHw(Venezia* v);
 
-    void create_input(mpq_t* input_q, int num_inputs);
+    void create_input(mpq_t* input_q, int num_inputs, char *argv[]);
   private:
     Venezia* v;
     ${computation_classname}VerifierInpGen compiler_implementation;

--- a/compiler/backend/templates/verifier_lite_inp_gen.h.tmpl
+++ b/compiler/backend/templates/verifier_lite_inp_gen.h.tmpl
@@ -1,11 +1,11 @@
 \#include <iostream>
 \#include <fstream>
-\#include <string> 
+\#include <string>
 
 \#include <gmp.h>
 
 \#include <input_generation/${computation_classname}_v_inp_gen.h>
 
-void gen_input (mpq_t * input_q, int num_inputs) {
-    ${computation_classname}_input_gen(input_q, num_inputs);
+void gen_input (mpq_t * input_q, int num_inputs, char *argv[]) {
+    ${computation_classname}_input_gen(input_q, num_inputs, argv);
 }

--- a/compiler/backend/templates/verifier_lite_inp_gen_impl.h.tmpl
+++ b/compiler/backend/templates/verifier_lite_inp_gen_impl.h.tmpl
@@ -1,6 +1,6 @@
 
 
-void ${computation_classname}_input_gen (mpq_t * input_q, int num_inputs) {
+void ${computation_classname}_input_gen (mpq_t * input_q, int num_inputs, char *argv[]) {
 
     for (int i = 0; i < num_inputs; i++) {
         mpq_set_ui(input_q[i], rand(), 1);

--- a/pepper/input_generation/boyer_occur_benes_v_inp_gen.h
+++ b/pepper/input_generation/boyer_occur_benes_v_inp_gen.h
@@ -1,6 +1,6 @@
 #include <apps/boyer_occur_benes.h>
 
-void boyer_occur_benes_input_gen (mpq_t * input_q, int num_inputs) {
+void boyer_occur_benes_input_gen (mpq_t * input_q, int num_inputs, char *argv[]) {
 
 
     srand(time(NULL));

--- a/pepper/input_generation/boyer_occur_merkle_v_inp_gen.h
+++ b/pepper/input_generation/boyer_occur_merkle_v_inp_gen.h
@@ -4,7 +4,7 @@
 #include <storage/configurable_block_store.h>
 
 
-void boyer_occur_merkle_input_gen (mpq_t * input_q, int num_inputs) {
+void boyer_occur_merkle_input_gen (mpq_t * input_q, int num_inputs, char *argv[]) {
 
     char db_file_path[BUFLEN];
     snprintf(db_file_path, BUFLEN - 1, "%s/block_stores/prover_%s", FOLDER_STATE, "default_shared_db");

--- a/pepper/input_generation/fannkuch_v_inp_gen.h
+++ b/pepper/input_generation/fannkuch_v_inp_gen.h
@@ -1,6 +1,6 @@
 
 
-void fannkuch_input_gen (mpq_t * input_q, int num_inputs) {
+void fannkuch_input_gen (mpq_t * input_q, int num_inputs, char *argv[]) {
 
     int m = 13;
 

--- a/pepper/input_generation/kmpsearch_flat_v_inp_gen.h
+++ b/pepper/input_generation/kmpsearch_flat_v_inp_gen.h
@@ -1,6 +1,6 @@
 
 
-void kmpsearch_flat_input_gen (mpq_t * input_q, int num_inputs) {
+void kmpsearch_flat_input_gen (mpq_t * input_q, int num_inputs, char *argv[]) {
 
     for (int i = 0; i < num_inputs; i++) {
         mpq_set_ui(input_q[i], rand() % 256, 1);

--- a/pepper/input_generation/kmpsearch_v_inp_gen.h
+++ b/pepper/input_generation/kmpsearch_v_inp_gen.h
@@ -1,6 +1,6 @@
 
 
-void kmpsearch_input_gen (mpq_t * input_q, int num_inputs) {
+void kmpsearch_input_gen (mpq_t * input_q, int num_inputs, char *argv[]) {
 
     for (int i = 0; i < num_inputs; i++) {
         mpq_set_ui(input_q[i], rand() % 256, 1);

--- a/pepper/input_generation/mergesort_benes_v_inp_gen.h
+++ b/pepper/input_generation/mergesort_benes_v_inp_gen.h
@@ -1,6 +1,6 @@
 
 
-void mergesort_benes_input_gen (mpq_t * input_q, int num_inputs) {
+void mergesort_benes_input_gen (mpq_t * input_q, int num_inputs, char *argv[]) {
 
     for (int i = 0; i < num_inputs; i++) {
         mpq_set_ui(input_q[i], rand() % 10, 1);

--- a/pepper/input_generation/mergesort_merkle_v_inp_gen.h
+++ b/pepper/input_generation/mergesort_merkle_v_inp_gen.h
@@ -3,7 +3,7 @@
 #include <storage/hasher.h>
 #include <storage/configurable_block_store.h>
 
-void mergesort_merkle_input_gen (mpq_t * input_q, int num_inputs) {
+void mergesort_merkle_input_gen (mpq_t * input_q, int num_inputs, char *argv[]) {
 
     char db_file_path[BUFLEN];
     snprintf(db_file_path, BUFLEN - 1, "%s/block_stores/prover_%s", FOLDER_STATE, "default_shared_db");

--- a/pepper/input_generation/mm_pure_arith_v_inp_gen.h
+++ b/pepper/input_generation/mm_pure_arith_v_inp_gen.h
@@ -1,6 +1,6 @@
 
 
-void mm_pure_arith_input_gen (mpq_t * input_q, int num_inputs) {
+void mm_pure_arith_input_gen (mpq_t * input_q, int num_inputs, char *argv[]) {
 
     for (int i = 0; i < num_inputs; i++) {
         mpq_set_ui(input_q[i], rand(), 1);

--- a/pepper/input_generation/pam_clustering_v_inp_gen.h
+++ b/pepper/input_generation/pam_clustering_v_inp_gen.h
@@ -1,6 +1,6 @@
 
 
-void pam_clustering_input_gen (mpq_t * input_q, int num_inputs) {
+void pam_clustering_input_gen (mpq_t * input_q, int num_inputs, char *argv[]) {
 
     for (int i = 0; i < num_inputs; i++) {
         mpq_set_ui(input_q[i], rand(), 1);

--- a/pepper/input_generation/prover_knows_hash_preimage_v_inp_gen.h
+++ b/pepper/input_generation/prover_knows_hash_preimage_v_inp_gen.h
@@ -2,7 +2,7 @@
 uint8_t sha256_hash[32] = { 136, 212, 38, 111, 212, 230, 51, 141, 19, 184, 69, 252, 242, 137, 87, 157, 32, 156, 137, 120, 35, 185, 33, 125, 163, 225, 97, 147, 111, 3, 21, 137 };
 // sha256 hash of 'a', 'b', 'c', 'd'
 
-void prover_knows_hash_preimage_input_gen (mpq_t * input_q, int num_inputs) {
+void prover_knows_hash_preimage_input_gen (mpq_t * input_q, int num_inputs, char *argv[]) {
 
     for (int i = 0; i < num_inputs; i++) {
         mpq_set_ui(input_q[i], sha256_hash[i], 1);

--- a/pepper/input_generation/ptrchase_benes_v_inp_gen.h
+++ b/pepper/input_generation/ptrchase_benes_v_inp_gen.h
@@ -1,6 +1,6 @@
 
 
-void ptrchase_benes_input_gen (mpq_t * input_q, int num_inputs) {
+void ptrchase_benes_input_gen (mpq_t * input_q, int num_inputs, char *argv[]) {
   for(int i=0; i < num_inputs-1; i++) {
       mpq_set_ui(input_q[i], i+1, 1);
   }

--- a/pepper/input_generation/ptrchase_merkle_v_inp_gen.h
+++ b/pepper/input_generation/ptrchase_merkle_v_inp_gen.h
@@ -3,8 +3,8 @@
 #include <storage/hasher.h>
 #include <storage/configurable_block_store.h>
 
-void ptrchase_merkle_input_gen (mpq_t * input_q, int num_inputs) {
-    
+void ptrchase_merkle_input_gen (mpq_t * input_q, int num_inputs, char *argv[]) {
+
     char db_file_path[BUFLEN];
     snprintf(db_file_path, BUFLEN - 1, "%s/block_stores/prover_%s", FOLDER_STATE, "default_shared_db");
     ConfigurableBlockStore bs(db_file_path);

--- a/pepper/input_generation/pure_hashget_v_inp_gen.h
+++ b/pepper/input_generation/pure_hashget_v_inp_gen.h
@@ -1,8 +1,8 @@
 #include <apps/pure_hashget.h>
 #include <storage/configurable_block_store.h>
 #include <storage/ram_impl.h>
-void pure_hashget_input_gen (mpq_t * input_q, int num_inputs) {
-    
+void pure_hashget_input_gen (mpq_t * input_q, int num_inputs, char *argv[]) {
+
   struct In input;
   struct Out output;
   char db_file_path[BUFLEN];
@@ -24,5 +24,5 @@ void pure_hashget_input_gen (mpq_t * input_q, int num_inputs) {
     mpq_set_ui(input_q[i], input_ptr[i], 1);
   }
   deleteBlockStoreAndRAM();
-  
+
 }

--- a/pepper/input_generation/pure_hashput_v_inp_gen.h
+++ b/pepper/input_generation/pure_hashput_v_inp_gen.h
@@ -1,6 +1,6 @@
 
 
-void pure_hashput_input_gen (mpq_t * input_q, int num_inputs) {
+void pure_hashput_input_gen (mpq_t * input_q, int num_inputs, char *argv[]) {
 
     for (int i = 0; i < num_inputs; i++) {
         mpq_set_ui(input_q[i], rand(), 1);

--- a/pepper/input_generation/rle_decode_flat_v_inp_gen.h
+++ b/pepper/input_generation/rle_decode_flat_v_inp_gen.h
@@ -1,6 +1,6 @@
 
 
-void rle_decode_flat_input_gen (mpq_t * input_q, int num_inputs) {
+void rle_decode_flat_input_gen (mpq_t * input_q, int num_inputs, char *argv[]) {
 
     for (int i = 0; i < num_inputs; i++) {
         mpq_set_ui(input_q[i], rand() % 10, 1);

--- a/pepper/input_generation/rle_decode_v_inp_gen.h
+++ b/pepper/input_generation/rle_decode_v_inp_gen.h
@@ -1,6 +1,6 @@
 
 
-void rle_decode_input_gen (mpq_t * input_q, int num_inputs) {
+void rle_decode_input_gen (mpq_t * input_q, int num_inputs, char *argv[]) {
 
     for (int i = 0; i < num_inputs; i++) {
         mpq_set_ui(input_q[i], rand() % 10, 1);

--- a/pepper/input_generation/sparse_matvec_flat_v_inp_gen.h
+++ b/pepper/input_generation/sparse_matvec_flat_v_inp_gen.h
@@ -1,6 +1,6 @@
 #include <apps/sparse_matvec_flat.h>
 
-void sparse_matvec_flat_input_gen (mpq_t * input_q, int num_inputs) {
+void sparse_matvec_flat_input_gen (mpq_t * input_q, int num_inputs, char *argv[]) {
   srand(time(NULL));
   // randomly distribute elements into rows
   int buckets[N] = {0,};

--- a/pepper/input_generation/sparse_matvec_v_inp_gen.h
+++ b/pepper/input_generation/sparse_matvec_v_inp_gen.h
@@ -1,7 +1,7 @@
 #include <apps/sparse_matvec.h>
 
-void sparse_matvec_input_gen (mpq_t * input_q, int num_inputs) {
-    
+void sparse_matvec_input_gen (mpq_t * input_q, int num_inputs, char *argv[]) {
+
   srand(time(NULL));
   // randomly distribute elements into rows
   int buckets[N] = {0,};

--- a/pepper/input_generation/tolling_v_inp_gen.h
+++ b/pepper/input_generation/tolling_v_inp_gen.h
@@ -2,7 +2,7 @@
 #include <apps/tolling.h>
 
 
-int set_tuple(mpq_t* input_q, int inp, t_tuple_t* t_tuple){
+int set_tuple(mpq_t* input_q, int inp, t_tuple_t* t_tuple, char *argv[]){
   mpq_set_si(input_q[inp++], t_tuple->time, 1);
   mpq_set_ui(input_q[inp++], t_tuple->toll_booth_id, 1);
   mpq_set_ui(input_q[inp++], t_tuple->toll, 1);
@@ -29,9 +29,9 @@ void tolling_input_gen (mpq_t * input_q, int num_inputs) {
     //CK bit string acting like a salt
     commitmentCK_t CK = {{
             //Randomly generated.
-            0x8a, 0xf7, 0x24, 0xa1, 0x58, 
-            0xc9, 0x8b, 0x89, 0x29, 0x85, 
-            0xce, 0xa1, 0xae, 0xc3, 0x42, 
+            0x8a, 0xf7, 0x24, 0xa1, 0x58,
+            0xc9, 0x8b, 0x89, 0x29, 0x85,
+            0xce, 0xa1, 0xae, 0xc3, 0x42,
             0x6e, 0xbb, 0x86, 0x56, 0x37
         }};
     setcommitmentCK(&CK);
@@ -49,7 +49,7 @@ void tolling_input_gen (mpq_t * input_q, int num_inputs) {
     for(i = 0; i < NUM_COMMITMENT_CHUNKS; i++){
         mpq_set_ui(input_q[inp++], commitment.bit[i], 1);
     }
-    
+
     //Fill in the rest of the input (verifier's inputs)
     for(i = 0; i < MAX_SPOTCHECKS; i++){
         //Choose the ith tuple in the db

--- a/pepper/pepper_verifier.cpp
+++ b/pepper/pepper_verifier.cpp
@@ -27,9 +27,9 @@ void print_usage(char* argv[]) {
 
 void run_setup(int num_constraints, int num_inputs,
                int num_outputs, int num_vars, mpz_t p,
-               string vkey_file, string pkey_file, 
+               string vkey_file, string pkey_file,
                string unprocessed_vkey_file) {
-    
+
     std::ifstream Amat("./bin/" + std::string(NAME) + ".qap.matrix_a");
     std::ifstream Bmat("./bin/" + std::string(NAME) + ".qap.matrix_b");
     std::ifstream Cmat("./bin/" + std::string(NAME) + ".qap.matrix_c");
@@ -54,7 +54,7 @@ void run_setup(int num_constraints, int num_inputs,
     if (mpz_sgn(Acoef) == -1) {
         mpz_add(Acoef, p, Acoef);
     }
-    
+
     //    std::cout << Ai << " " << Aj << " " << Acoef << std::std::endl;
 
     Bmat >> Bi;
@@ -67,7 +67,7 @@ void run_setup(int num_constraints, int num_inputs,
     if (mpz_sgn(Bcoef) == -1) {
         mpz_add(Bcoef, p, Bcoef);
     }
-    
+
     Cmat >> Ci;
     Cmat >> Cj;
     Cmat >> Ccoef;
@@ -82,23 +82,23 @@ void run_setup(int num_constraints, int num_inputs,
         mpz_mul_si(Ccoef, Ccoef, -1);
         mpz_add(Ccoef, p, Ccoef);
     }
-    
+
     int num_intermediate_vars = num_vars;
     int num_inputs_outputs = num_inputs + num_outputs;
-    
+
     q.primary_input_size = num_inputs_outputs;
     q.auxiliary_input_size = num_intermediate_vars;
-    
+
     for (int currentconstraint = 1; currentconstraint <= num_constraints; currentconstraint++) {
         libsnark::linear_combination<FieldT> A, B, C;
-        
-        while(Aj == currentconstraint && Amat) {                  
+
+        while(Aj == currentconstraint && Amat) {
             if (Ai <= num_intermediate_vars && Ai != 0) {
                 Ai += num_inputs_outputs;
             } else if (Ai > num_intermediate_vars) {
                 Ai -= num_intermediate_vars;
             }
-            
+
             FieldT AcoefT(Acoef);
             A.add_term(Ai, AcoefT);
             if(!Amat) {
@@ -106,7 +106,7 @@ void run_setup(int num_constraints, int num_inputs,
             }
             Amat >> Ai;
             Amat >> Aj;
-            Amat >> Acoef; 
+            Amat >> Acoef;
             if (mpz_cmpabs(Acoef, p) > 0) {
                 gmp_printf("WARNING: Coefficient larger than prime (%Zd > %Zd).\n", Acoef, p);
                 mpz_mod(Acoef, Acoef, p);
@@ -115,7 +115,7 @@ void run_setup(int num_constraints, int num_inputs,
                 mpz_add(Acoef, p, Acoef);
             }
         }
-        
+
         while(Bj == currentconstraint && Bmat) {
             if (Bi <= num_intermediate_vars && Bi != 0) {
                 Bi += num_inputs_outputs;
@@ -139,7 +139,7 @@ void run_setup(int num_constraints, int num_inputs,
                 mpz_add(Bcoef, p, Bcoef);
             }
         }
-        
+
         while(Cj == currentconstraint && Cmat) {
             if (Ci <= num_intermediate_vars && Ci != 0) {
                 Ci += num_inputs_outputs;
@@ -147,8 +147,8 @@ void run_setup(int num_constraints, int num_inputs,
                 Ci -= num_intermediate_vars;
             }
             //Libsnark constraints are A*B = C, vs. A*B - C = 0 for Zaatar.
-            //Which is why the C coefficient is negated. 
-            
+            //Which is why the C coefficient is negated.
+
             // std::cout << Ci << " " << Cj << " " << Ccoef << std::std::endl;
             FieldT CcoefT(Ccoef);
             C.add_term(Ci, CcoefT);
@@ -169,12 +169,12 @@ void run_setup(int num_constraints, int num_inputs,
                 mpz_add(Ccoef, p, Ccoef);
             }
         }
-        
+
         q.add_constraint(libsnark::r1cs_constraint<FieldT>(A, B, C));
-        
+
         //dump_constraint(r1cs_constraint<FieldT>(A, B, C), va, variable_annotations);
     }
-    
+
     Amat.close();
     Bmat.close();
     Cmat.close();
@@ -202,17 +202,17 @@ void verify (string verification_key_fn, string inputs_fn, string outputs_fn,
              string proof_fn, int num_inputs, int num_outputs, mpz_t prime) {
 
     libsnark::default_r1cs_ppzksnark_pp::init_public_params();
-   
+
     libsnark::r1cs_variable_assignment<FieldT> inputvec;
     libsnark::r1cs_ppzksnark_proof<libsnark::default_r1cs_ppzksnark_pp> proof;
-    
+
     std::cout << "loading proof from file: " << proof_fn << std::endl;
     std::ifstream proof_file(proof_fn);
     if (!proof_file.good()) {
         std::cerr << "ERROR: " << proof_fn << " not found. " << std::endl;
         exit(1);
     }
-    proof_file >> proof; 
+    proof_file >> proof;
     proof_file.close();
 
     std::cout << "loading inputs from file: " << inputs_fn << std::endl;
@@ -223,7 +223,7 @@ void verify (string verification_key_fn, string inputs_fn, string outputs_fn,
 
     mpq_t tmp; mpq_init(tmp);
     mpz_t tmp_z; mpz_init(tmp_z);
-    
+
     for (int i = 0; i < num_inputs; i++) {
         inputs_file >> tmp;
         convert_to_z(tmp_z, tmp, prime);
@@ -235,11 +235,11 @@ void verify (string verification_key_fn, string inputs_fn, string outputs_fn,
         outputs_file >> tmp;
         convert_to_z(tmp_z, tmp, prime);
         FieldT currentVar(tmp_z);
-        inputvec.push_back(currentVar); 
+        inputvec.push_back(currentVar);
     }
 
     mpq_clear(tmp); mpz_clear(tmp_z);
-    
+
     inputs_file.close();
     outputs_file.close();
 
@@ -252,7 +252,7 @@ void verify (string verification_key_fn, string inputs_fn, string outputs_fn,
     cout << "verifying..." << std::endl;
     libff::start_profiling();
     bool result = libsnark::r1cs_ppzksnark_online_verifier_strong_IC<libsnark::default_r1cs_ppzksnark_pp>(pvk, inputvec, proof);
-   
+
     if (result) {
         cout << "VERIFICATION SUCCESSFUL" << std::endl;
     }
@@ -267,7 +267,7 @@ int main (int argc, char* argv[]) {
         print_usage(argv);
         exit(1);
     }
-    
+
     struct comp_params p = parse_params("./bin/" + string(NAME) + ".params");
 
     mpz_t prime;
@@ -291,7 +291,7 @@ int main (int argc, char* argv[]) {
         run_setup(p.n_constraints, p.n_inputs, p.n_outputs, p.n_vars, prime, verification_key_fn, proving_key_fn, unprocessed_vkey_fn);
     }
     else if (!strcmp(argv[1], "gen_input")) {
-        if (argc != 3) {
+        if (argc < 3) {
             print_usage(argv);
             exit(1);
         }
@@ -302,10 +302,10 @@ int main (int argc, char* argv[]) {
         mpq_t * input_q;
         alloc_init_vec(&input_q, p.n_inputs);
 
-        gen_input(input_q, p.n_inputs);
+        gen_input(input_q, p.n_inputs, argv);
 
         std::ofstream inputs_file(input_filename);
-        
+
         for (int i = 0; i < p.n_inputs; i++) {
             inputs_file << input_q[i] << std::endl;
         }
@@ -329,4 +329,3 @@ int main (int argc, char* argv[]) {
         exit(1);
     }
 }
-


### PR DESCRIPTION
This PR pass the `argv` variable to the corresponding input generation function.

A useful feature where the input generation function is parameterized by external factors

**Real case scenario**:

The input generation function takes as input a hash value in hex and transform it to a bytearray which is passed to `input_q`

**Command:**

`bin/pepper_verifier_prover_knows_hash_preimage gen_input prover_knows_hash_preimage.inputs 88d4266fd4e6338d13b845fcf289579d209c897823b9217da3e161936f031589`

**Sample Code**

```
#include <iostream>
#include <string>
#include <vector>
#include <sstream>
#include <limits.h>
#include <unistd.h>

void hex_to_bytearray(std::string str, std::vector<int> &array)
{
	int length = str.length();
	// make sure the input string has an even digit numbers
	if(length%2 == 1)
	{
		str = "0" + str;
		length++;
	}

	// allocate memory for the output array
	array.reserve(length/2);

	std::stringstream sstr(str);
	for(int i=0; i < length/2; i++)
	{
		char ch1, ch2;
		sstr >> ch1 >> ch2;
		int dig1, dig2;
		if(isdigit(ch1)) dig1 = ch1 - '0';
		else if(ch1>='A' && ch1<='F') dig1 = ch1 - 'A' + 10;
		else if(ch1>='a' && ch1<='f') dig1 = ch1 - 'a' + 10;
		if(isdigit(ch2)) dig2 = ch2 - '0';
		else if(ch2>='A' && ch2<='F') dig2 = ch2 - 'A' + 10;
		else if(ch2>='a' && ch2<='f') dig2 = ch2 - 'a' + 10;
		array.push_back(dig1*16 + dig2);
	}
}

void prover_knows_hash_preimage_input_gen (mpq_t * input_q, int num_inputs, char *argv[]) {

    std::vector<int> bytearray;
    std::string hash = argv[3];

    hex_to_bytearray(hash, bytearray);

    for (int i = 0; i < num_inputs; i++) {
        mpq_set_ui(input_q[i],  bytearray[i], 1);
    }
}
```
