### PR TITLE
 Adding a mode to export only the witness when generating proof

### DIFF
--- a/pepper/Makefile
+++ b/pepper/Makefile
@@ -2,7 +2,7 @@ CXX = g++
 
 # according to libsnark's documentation, we need to use the same conditional defines libsnark was compiled with, as found in
 # thirdparty/libsnark/build/libsnark/CMakeFiles/snark.dir/flags.make
-CXXFLAGS = -m64 -std=c++11 -DCURVE_BN128 -DBN_SUPPORT_SNARK -DBINARY_OUTPUT -DMONTGOMERY_OUTPUT -DNO_PROCPS -DUSE_ASM
+CXXFLAGS = -m64 -std=c++11 -DCURVE_BN128 -DBN_SUPPORT_SNARK -UBINARY_OUTPUT -DMONTGOMERY_OUTPUT -DNO_PROCPS -DUSE_ASM
 
 AR	:= ar rcs
 

--- a/pepper/Makefile
+++ b/pepper/Makefile
@@ -2,7 +2,7 @@ CXX = g++
 
 # according to libsnark's documentation, we need to use the same conditional defines libsnark was compiled with, as found in
 # thirdparty/libsnark/build/libsnark/CMakeFiles/snark.dir/flags.make
-CXXFLAGS = -m64 -std=c++11 -DCURVE_BN128 -DBN_SUPPORT_SNARK -UBINARY_OUTPUT -DMONTGOMERY_OUTPUT -DNO_PROCPS -DUSE_ASM
+CXXFLAGS = -m64 -std=c++11 -DCURVE_BN128 -DBN_SUPPORT_SNARK -DBINARY_OUTPUT -DMONTGOMERY_OUTPUT -DNO_PROCPS -DUSE_ASM
 
 AR	:= ar rcs
 


### PR DESCRIPTION
We are experimenting with DIZK (https://github.com/scipr-lab/dizk), which parallelises the expensive SNARK operations (verification key generation and proof generation) on an AWS cluster. DIZK requires the R1CS as well as the witness as an input.

We would like to use pepper to compile higher level C code into the R1CS and also use pepper's solver to compute the witness. 
This PR introduces a way to export the witness information without doing any of the key of proof generation.