### PR TITLE
Add prover-knows-factorization zkp example: factors remain private.

### DIFF
--- a/pepper/apps/exo1
+++ b/pepper/apps/exo1
@@ -1,0 +1,22 @@
+#!/bin/sh
+
+echo 7
+echo 43
+echo 1
+echo 1
+echo 1
+echo 1
+echo 1
+echo 1
+echo 1
+echo 1
+
+##### Explanation and usage ####
+
+# The prime factors of 301 are 7 and 43. 
+# However, larger primes have more than just 2 factors. The number of factors should be oblivious 
+# to both the program (pepper/apps/prover_knows_factorization.c) and the verifier. 
+
+# Thus, we use an upper bound (NUM_OF_FACTORS_UPPER_BOUND = 10) to the number of factors.
+# If the factors are less than NUM_OF_FACTORS_UPPER_BOUND, the rest should be filled with 1.
+

--- a/pepper/apps/exo1
+++ b/pepper/apps/exo1
@@ -14,7 +14,7 @@ echo 1
 ##### Explanation and usage ####
 
 # The prime factors of 301 are 7 and 43. 
-# However, larger primes have more than just 2 factors. The number of factors should be oblivious 
+# However, larger numbers have more than just 2 factors. The number of factors should be oblivious 
 # to both the program (pepper/apps/prover_knows_factorization.c) and the verifier. 
 
 # Thus, we use an upper bound (NUM_OF_FACTORS_UPPER_BOUND = 10) to the number of factors.

--- a/pepper/apps/prover_knows_factorization.c
+++ b/pepper/apps/prover_knows_factorization.c
@@ -6,26 +6,26 @@
  * 1) Verifier sets up the P and V keys:
  *      ./pepper_compile_and_setup_V.sh prover_knows_factorization prover_knows_factorization.vkey prover_knows_factorization.pkey
  *
- * 2) Prover claims that she knows the factors of the prime (located in the exo1 file) Note: exo1 should be executable and placed inside pequin/pepper/bin directory
+ * 2) Prover claims that she knows the factors of the large number (located in the exo1 file) Note: exo1 should be executable and placed inside pequin/pepper/bin directory
  *      ./pepper_compile_and_setup_P.sh prover_knows_factorization
  *
- * 3) Verifier generates and provides the prime (located in the prover_knows_factorization.inputs file)
+ * 3) Verifier generates and provides the number (located in the prover_knows_factorization.inputs file)
  *      bin/pepper_verifier_prover_knows_factorization gen_input prover_knows_factorization.inputs
  *
  * 4) Prover generates a proof (prover_knows_factorization.proof) that he knows the factors
  *      bin/pepper_prover_prover_knows_factorization prove prover_knows_factorization.pkey prover_knows_factorization.inputs prover_knows_factorization.outputs prover_knows_factorization.proof
  *
- * 5) Finally, Verifier checks the computation without ever knowing the preimage
+ * 5) Finally, Verifier checks the computation without ever knowing the factors.
  *      bin/pepper_verifier_prover_knows_factorization verify prover_knows_factorization.vkey prover_knows_factorization.inputs prover_knows_factorization.outputs prover_knows_factorization.proof
 **/
 
 void compute(struct In *input, struct Out *output) {
     uint32_t i;
-    uint32_t *public_prime[1] = { input->prime };        /* This is the prime that Prover claims that knows its factorization (provided by pepper/input_generation/prover_knows_factorization_v_inp_gen.h) */
-    factors_t factors[1];                           /* Prover will fill it with his private factors (provided by exo1) */
-    uint32_t len[1] = { 1 };                        /* Length of public_prime array: 1 prime */
+    uint32_t *public_num[1] = { input->input_num };         /* This is the input-number that Prover claims that knows its factorization (provided by pepper/input_generation/prover_knows_factorization_v_inp_gen.h) */
+    factors_t factors[1];                                   /* Prover will fill it with his private factors (provided by exo1) */
+    uint32_t len[1] = { 1 };                                /* Length of public_num array: 1 number */
     
-    exo_compute(public_prime, len, factors, 1);     /* Fill public_prime vector with prover's private factors */
+    exo_compute(public_num, len, factors, 1);               /* Fill public_num vector with prover's private factors */
     
     /* provers_computed_number = f1 * f2 * ... * fn */
     uint32_t provers_computed_number = 1;
@@ -33,7 +33,7 @@ void compute(struct In *input, struct Out *output) {
         provers_computed_number *= factors[0].factors[i];
     }
     
-    if (public_prime[0][0] == provers_computed_number) {    /* Finally check if the two numbers are equal */
+    if (public_num[0][0] == provers_computed_number) {      /* Finally check if the two numbers are equal */
         output->prover_knows_factors = 1;
     } else {
         output->prover_knows_factors = 0;

--- a/pepper/apps/prover_knows_factorization.c
+++ b/pepper/apps/prover_knows_factorization.c
@@ -1,0 +1,42 @@
+#include <prover_knows_factorization.h>
+
+/**
+ * Algorithm Description:
+ *
+ * 1) Verifier sets up the P and V keys:
+ *      ./pepper_compile_and_setup_V.sh prover_knows_factorization prover_knows_factorization.vkey prover_knows_factorization.pkey
+ *
+ * 2) Prover claims that she knows the factors of the prime (located in the exo1 file) Note: exo1 should be executable and placed inside pequin/pepper/bin directory
+ *      ./pepper_compile_and_setup_P.sh prover_knows_factorization
+ *
+ * 3) Verifier generates and provides the prime (located in the prover_knows_factorization.inputs file)
+ *      bin/pepper_verifier_prover_knows_factorization gen_input prover_knows_factorization.inputs
+ *
+ * 4) Prover generates a proof (prover_knows_factorization.proof) that he knows the factors
+ *      bin/pepper_prover_prover_knows_factorization prove prover_knows_factorization.pkey prover_knows_factorization.inputs prover_knows_factorization.outputs prover_knows_factorization.proof
+ *
+ * 5) Finally, Verifier checks the computation without ever knowing the preimage
+ *      bin/pepper_verifier_prover_knows_factorization verify prover_knows_factorization.vkey prover_knows_factorization.inputs prover_knows_factorization.outputs prover_knows_factorization.proof
+**/
+
+void compute(struct In *input, struct Out *output) {
+    uint32_t i;
+    uint32_t *public_prime[1] = { input->prime };        /* This is the prime that Prover claims that knows its factorization (provided by pepper/input_generation/prover_knows_factorization_v_inp_gen.h) */
+    factors_t factors[1];                           /* Prover will fill it with his private factors (provided by exo1) */
+    uint32_t len[1] = { 1 };                        /* Length of public_prime array: 1 prime */
+    
+    exo_compute(public_prime, len, factors, 1);     /* Fill public_prime vector with prover's private factors */
+    
+    /* provers_computed_number = f1 * f2 * ... * fn */
+    uint32_t provers_computed_number = 1;
+    for (i = 0 ; i < NUM_OF_FACTORS_UPPER_BOUND ; i++) {    /* Obliviously multiply until an upper bound */
+        provers_computed_number *= factors[0].factors[i];
+    }
+    
+    if (public_prime[0][0] == provers_computed_number) {    /* Finally check if the two numbers are equal */
+        output->prover_knows_factors = 1;
+    } else {
+        output->prover_knows_factors = 0;
+    }
+
+}

--- a/pepper/apps/prover_knows_factorization.h
+++ b/pepper/apps/prover_knows_factorization.h
@@ -5,14 +5,14 @@
 /**
  * Explanation and usage of NUM_OF_FACTORS_UPPER_BOUND
  *
- * Large primes have more than just 2 factors. The number of factors should be oblivious 
+ * Large numbers have more than just 2 factors. The number of factors should be oblivious 
  * to both the program (pepper/apps/prover_knows_factorization.c) and the verifier.
  * Thus, we use an upper bound (NUM_OF_FACTORS_UPPER_BOUND = 10) to the number of factors.
  * If the factors are less than NUM_OF_FACTORS_UPPER_BOUND, the rest should be filled with 1.
 **/
 
 struct In {
-    uint32_t prime[1];            			/* public prime */
+    uint32_t input_num[1];            			/* public input number */
 };
 
 struct Out {

--- a/pepper/apps/prover_knows_factorization.h
+++ b/pepper/apps/prover_knows_factorization.h
@@ -1,0 +1,24 @@
+#include <stdint.h>
+
+#define NUM_OF_FACTORS_UPPER_BOUND 10
+
+/**
+ * Explanation and usage of NUM_OF_FACTORS_UPPER_BOUND
+ *
+ * Large primes have more than just 2 factors. The number of factors should be oblivious 
+ * to both the program (pepper/apps/prover_knows_factorization.c) and the verifier.
+ * Thus, we use an upper bound (NUM_OF_FACTORS_UPPER_BOUND = 10) to the number of factors.
+ * If the factors are less than NUM_OF_FACTORS_UPPER_BOUND, the rest should be filled with 1.
+**/
+
+struct In {
+    uint32_t prime[1];            			/* public prime */
+};
+
+struct Out {
+    uint8_t prover_knows_factors; 	        /* boolean output */
+};
+
+typedef struct factors { 
+    uint32_t factors[NUM_OF_FACTORS_UPPER_BOUND]; 	/* private factors (prover will provide and multiply them) to prove that he knows them */
+} factors_t;

--- a/pepper/input_generation/prover_knows_factorization_v_inp_gen.h
+++ b/pepper/input_generation/prover_knows_factorization_v_inp_gen.h
@@ -1,9 +1,9 @@
 
-uint64_t prime = 301;
+uint64_t number = 301;
 // 7 * 43 = 301
 
 void prover_knows_factorization_input_gen(mpq_t * input_q, int num_inputs, char *argv[]) {
     for (int i = 0; i < num_inputs; i++) {
-        mpq_set_ui(input_q[i], prime, 1);
+        mpq_set_ui(input_q[i], number, 1);
     }
 }

--- a/pepper/input_generation/prover_knows_factorization_v_inp_gen.h
+++ b/pepper/input_generation/prover_knows_factorization_v_inp_gen.h
@@ -1,0 +1,9 @@
+
+uint64_t prime = 301;
+// 7 * 43 = 301
+
+void prover_knows_factorization_input_gen(mpq_t * input_q, int num_inputs, char *argv[]) {
+    for (int i = 0; i < num_inputs; i++) {
+        mpq_set_ui(input_q[i], prime, 1);
+    }
+}


### PR DESCRIPTION
Implementation of another realistic use-case as in PR #27. **A prover claims that knows the factors of a big number.**

Description:
1. Verifier sets up the P and V keys:
`./pepper_compile_and_setup_V.sh prover_knows_factorization prover_knows_factorization.vkey prover_knows_factorization.pkey`

2. Prover claims that she knows the factors of the big number (located in the exo1 file).
**Note**: exo1 should be executable and placed inside pequin/pepper/bin directory
`./pepper_compile_and_setup_P.sh prover_knows_factorization`

3. Verifier generates and provides the number (located in the prover_knows_factorization.inputs file)
`bin/pepper_verifier_prover_knows_factorization gen_input prover_knows_factorization.inputs`

4. Prover generates a proof (prover_knows_factorization.proof) that he knows the factors
`bin/pepper_prover_prover_knows_factorization prove prover_knows_factorization.pkey prover_knows_factorization.inputs prover_knows_factorization.outputs prover_knows_factorization.proof`

5. Finally, Verifier checks the computation without ever knowing the factors.
`bin/pepper_verifier_prover_knows_factorization verify prover_knows_factorization.vkey prover_knows_factorization.inputs prover_knows_factorization.outputs prover_knows_factorization.proof`
