### PR TITLE
update type of lval after ramget using declared Type

### DIFF
--- a/compiler/frontend/src/SFE/Compiler/RamGetEnhancedStatement.java
+++ b/compiler/frontend/src/SFE/Compiler/RamGetEnhancedStatement.java
@@ -39,6 +39,16 @@ public class RamGetEnhancedStatement extends StatementWithOutputLine implements
 		if (value.size() > 1) {
 			for (int i = 0; i < value.size(); i++) {
 				LvalExpression lval = value.fieldEltAt(i);
+                if (lval.getLvalue() instanceof VarLvalue) {
+					Type declaredType = ((VarLvalue) lval.getLvalue()).getDeclaredType();
+					lval.getLvalue().setType(declaredType);
+				} else {
+					throw new RuntimeException("Failed to reset the type of the lvalue " +
+							lval.getLvalue().toString() + " to its declared type after " +
+							"ramget: I don't know how to determine the declared type " +
+							"of a " + lval.getClass() + "."
+					);
+				}
 				Expression fieldAddr = new BinaryOpExpression(new PlusOperator(),
 				    address, IntConstant.valueOf(i));
 				Statement ramget = new RamGetEnhancedStatement(lval, fieldAddr);


### PR DESCRIPTION
... and throw an error (with a meaningful description) if lval is not an instance of VarLvalue.

This is my fix for https://github.com/pepper-project/pequin/issues/59.

As far as i understand the problem, the above patch fixes the issue. I do not know if maybe there is another location in the code where the same problem occurs, you should have a look at that. The fix changes the type of the lvalue that has been created during the first initialisation of the variable. That undoes the optimization of the type. In my code example, this has no effect, as the value is overridden immediately; but it might have an effect if:

* the lvalue gets assigned some small (e.g. 1 bit) constants,
* then some operations are performed (that cannot be optimized at compile time),
* and only afterwards a value is assigned with ramget_fast.

In that scenario (which i have not tested) the patch might also change the type hint in the variable table retroactively and undo type optimizations. Might cause some issues if the type has been set to be bigger than the declared type? (Wouldn't be legal C code, but seems to be the current handling of integer overflows in pequin) But other than for optimization, the type of an lvalue does not seem to have any effect on the computation anyway. I might be completely wrong here, though.