### PR TITLE
Add pkg-config as a dependency for Ubuntu

### DIFF
--- a/install_debian_ubuntu.sh
+++ b/install_debian_ubuntu.sh
@@ -5,7 +5,7 @@ set -e
 PACKAGES="python2.7 libpython2.7 libpython2.7-dev golang \
           build-essential gcc g++ gcc-multilib g++-multilib ant \
           ant-optional make time libboost-all-dev libgmp10 libgmp-dev \
-          zlib1g zlib1g-dev libssl-dev cmake"
+          zlib1g zlib1g-dev libssl-dev cmake pkg-config"
 
 if [[ $(apt-cache search openjdk-8-jdk) ]]; then
     PACKAGES+=" openjdk-8-jdk"


### PR DESCRIPTION
This may seem obvious, but it was missing from my fresh 14.04 server install when I tried to build pequin.